### PR TITLE
fix references to old repository location

### DIFF
--- a/Documentation/iOSInstallation.md
+++ b/Documentation/iOSInstallation.md
@@ -10,11 +10,11 @@
 1-2.) choose `node_modules/react-native-webrtc/ios/RCTWebRTC.xcodeproj` then `Add`  
 1-3.) also add `node_modules/react-native-webrtc/ios/WebRTC.framework` to project root or anywhere you want:  
 
-![Picture 4](https://github.com/oney/react-native-webrtc/blob/master/Documentation/doc_install_xcode_add_xcodeproject.png)
+![Picture 4](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/doc_install_xcode_add_xcodeproject.png)
 
 1-4.) you will ended up with structure like:  
 
-![Picture 4](https://github.com/oney/react-native-webrtc/blob/master/Documentation/doc_install_xcode_file_structure.png)
+![Picture 4](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/doc_install_xcode_file_structure.png)
 
 ## iOS Podfile
 
@@ -32,7 +32,7 @@ pod 'react-native-webrtc', :path => '../node_modules/react-native-webrtc'
 2-2.) edit BOTH `Framework Search Paths` and `Library Search Paths`  
 2-3.) add path on BOTH sections with: `$(SRCROOT)/../node_modules/react-native-webrtc/ios` with `recursive`  
 
-![Picture 4](https://github.com/oney/react-native-webrtc/blob/master/Documentation/doc_install_xcode_search_path.png)
+![Picture 4](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/doc_install_xcode_search_path.png)
 
 ## Step 3. Change General Setting and Embed Framework
 
@@ -40,7 +40,7 @@ pod 'react-native-webrtc', :path => '../node_modules/react-native-webrtc'
 3-2.) change `Deployment Target` to `8.0`  
 3-3.) add `Embedded Binaries` like below:  
 
-![Picture 4](https://github.com/oney/react-native-webrtc/blob/master/Documentation/doc_install_xcode_embed_framework.png)
+![Picture 4](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/doc_install_xcode_embed_framework.png)
 
 
 ## Step 4. Link/Include Necessary Libraries
@@ -66,7 +66,7 @@ libsqlite3.tbd
 
 4-5.) Under `Build setting` set `Dead Code Stripping` to `No` also under `Build Options` set `Enable Bitcode` to `No` as well  
 
-![Picture 4](https://github.com/oney/react-native-webrtc/blob/master/Documentation/doc_install_xcode_link_libraries.png)
+![Picture 4](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/doc_install_xcode_link_libraries.png)
 
 ## Step 5. Add Permissions
 
@@ -99,11 +99,11 @@ try the cleaning steps below, and do it again carefully with every steps.
 You should strip simulator (i386/x86_64) archs from WebRTC binary before submit to Apple Store.  
 We provide a handy script to do it easily. see below sections.
 
-credit: The script is originally provided by [@besarthoxhaj](https://github.com/besarthoxhaj) in [#141](https://github.com/oney/react-native-webrtc/issues/141), thanks!
+credit: The script is originally provided by [@besarthoxhaj](https://github.com/besarthoxhaj) in [#141](https://github.com/react-native-webrtc/react-native-webrtc/issues/141), thanks!
 
 #### Strip Simulator Archs Usage
 
-The script and example are here: https://github.com/oney/react-native-webrtc/blob/master/tools/ios_arch.js
+The script and example are here: https://github.com/react-native-webrtc/react-native-webrtc/blob/master/tools/ios_arch.js
 
 1. go to `react-native-webrtc/tools` folder
 2. extract all archs first: `node ios_arch.js --extract`

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Everyone is welcome to you our [Discourse community](https://react-native-webrtc
 | 1.69.0 | [M69](https://chromium.googlesource.com/external/webrtc/+/branch-heads/69)<br>[commit](https://chromium.googlesource.com/external/webrtc/+/9110a54a60d9e0c69128338fc250319ddb751b5a)<br>(24012)<br>(+16-24348) | x86_64<br>i386<br>armv7<br>arm64 | armeabi-v7a<br>x86 | :heavy_check_mark: |  |  |
 | master | [M69](https://chromium.googlesource.com/external/webrtc/+/branch-heads/69)<br>[commit](https://chromium.googlesource.com/external/webrtc/+/9110a54a60d9e0c69128338fc250319ddb751b5a)<br>(24012)<br>(+16-24348) | x86_64<br>i386<br>armv7<br>arm64 | armeabi-v7a<br>x86 | :warning: | test me plz |  |
 
-Please see [wiki page](https://github.com/oney/react-native-webrtc/wiki) about revision history.
+Please see [wiki page](https://github.com/react-native-webrtc/react-native-webrtc/wiki) about revision history.
 
 ## Installation
 
-- [iOS](https://github.com/oney/react-native-webrtc/blob/master/Documentation/iOSInstallation.md)
-- [Android](https://github.com/oney/react-native-webrtc/blob/master/Documentation/AndroidInstallation.md)
+- [iOS](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/iOSInstallation.md)
+- [Android](https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/AndroidInstallation.md)
 
 ## Usage
 Now, you can use WebRTC like in browser.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.69.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oney/react-native-webrtc.git"
+    "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"
   },
   "nativePackage": true,
   "description": "WebRTC for React Native",
@@ -11,7 +11,7 @@
     "name": "Oney",
     "email": "appdevoney@gmail.com"
   },
-  "homepage": "https://github.com/oney/react-native-webrtc",
+  "homepage": "https://github.com/react-native-webrtc/react-native-webrtc",
   "keywords": [
     "react-component",
     "react-native",
@@ -28,6 +28,6 @@
     "react-native": ">=0.40.0"
   },
   "bugs": {
-    "url": "https://github.com/oney/react-native-webrtc/issues"
+    "url": "https://github.com/react-native-webrtc/react-native-webrtc/issues"
   }
 }

--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -6,10 +6,10 @@ Pod::Spec.new do |s|
   s.name                = package['name']
   s.version             = package['version']
   s.summary             = package['description']
-  s.homepage            = 'https://github.com/oney/react-native-webrtc'
+  s.homepage            = 'https://github.com/react-native-webrtc/react-native-webrtc'
   s.license             = package['license']
-  s.author              = 'https://github.com/oney/react-native-webrtc/graphs/contributors'
-  s.source              = { :git => 'git@github.com:oney/react-native-webrtc.git', :tag => 'release #{s.version}' }
+  s.author              = 'https://github.com/react-native-webrtc/react-native-webrtc/graphs/contributors'
+  s.source              = { :git => 'git@github.com:react-native-webrtc/react-native-webrtc.git', :tag => 'release #{s.version}' }
   s.requires_arc        = true
 
   s.platform            = :ios, '9.0'


### PR DESCRIPTION
Fix #617 

 - Fix links in readme to installation docs
 - Fix image embeds in installation docs
 - Fix other places the old `oney/react-native-webrtc` repo is referenced

[Preview of iOS Installation docs after this change](https://github.com/ruddell/react-native-webrtc/blob/fix-repo-links/Documentation/iOSInstallation.md)

We could also use relative links instead, but I don't expect the repo name will change again in the near future.