### PR TITLE
Add support for mediasoup

### DIFF
--- a/MediaStream.js
+++ b/MediaStream.js
@@ -47,6 +47,7 @@ export default class MediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
   }
 
   addTrack(track: MediaStreamTrack) {
+    if(track.kind==='video' && this.getVideoTracks().length===0 && track.streamReactTag) this.reactTag = track.streamReactTag;
     this._tracks.push(track);
     this.dispatchEvent(new MediaStreamTrackEvent('addtrack', {track}));
   }
@@ -59,6 +60,7 @@ export default class MediaStream extends EventTarget(MEDIA_STREAM_EVENTS) {
     WebRTCModule.mediaStreamTrackRelease(this.reactTag, track.id);
     this._tracks.splice(index, 1);
     this.dispatchEvent(new MediaStreamTrackEvent('removetrack', {track}));
+    if(this.getVideoTracks().length===0) this.reactTag = undefined;
   }
 
   getTracks(): Array<MediaStreamTrack> {

--- a/getUserMedia.js
+++ b/getUserMedia.js
@@ -141,7 +141,9 @@ export default function getUserMedia(constraints = {}) {
         /* successCallback */ (id, tracks) => {
           const stream = new MediaStream(id);
           for (const track of tracks) {
-            stream.addTrack(new MediaStreamTrack(track));
+            const mediaStreamTrack = new MediaStreamTrack(track);
+            mediaStreamTrack.streamReactTag = stream.reactTag;
+            stream.addTrack(mediaStreamTrack);
           }
     
           resolve(stream);


### PR DESCRIPTION
Signed-off-by: François Billioud <fbillioud@cutii.io>

The track needs to keep track of the stream that generated it, otherwise you will never be able to display it in an RTCView.