### PR TITLE
Add optional toJSON for candidate

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -186,7 +186,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
   addIceCandidate(candidate) {
     return new Promise((resolve, reject) => {
       WebRTCModule.peerConnectionAddICECandidate(
-        candidate.toJSON(),
+        candidate.toJSON ? candidate.toJSON() : candidate,
         this._peerConnectionId,
         (successful) => {
           if (successful) {


### PR DESCRIPTION
This fixes #582 and allows for `pc.addIceCandidate(null)` or `pc.addIceCandidate({ candidate, sdpMid, sdpMLineIndex })` with correct values resulting in a resolved promise. 