### PR TITLE
Fix mirror on landscape view

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -189,10 +189,17 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
     subview.frame = newValue;
   }
 
-  subview.transform
-    = self.mirror
-        ? CGAffineTransformMakeScale(-1.0, 1.0)
-        : CGAffineTransformIdentity;
+  if(self.mirror) {
+    if (CGRectGetWidth(subview.bounds) > CGRectGetHeight(subview.bounds)) {
+        // Landscape
+        subview.transform = CGAffineTransformMakeScale(1.0, -1.0);
+    } else {
+        // Portrait
+        subview.transform = CGAffineTransformMakeScale(-1.0, 1.0);
+    }
+  } else {
+    subview.transform = CGAffineTransformIdentity;
+  }
 }
 
 /**


### PR DESCRIPTION
I've confirmed this bug with a fresh project.  If you are mirroring the video and are in landscape mode the `subview.transform` logic flips the video vertically.  

It's unclear to me if this is the best approach as it seems like the subview should realize it's now horizontal and still be able to use `CGAffineTransformMakeScale` on its X axis.

If this isn't the best approach please point me in the right direction and I'd be happy to take a look.