### PR TITLE
Add note about upgrading the `platform` field in Podfile

### DIFF
--- a/Documentation/iOSInstallation.md
+++ b/Documentation/iOSInstallation.md
@@ -26,6 +26,12 @@ Include in a Podfile in your react-native ios directory:
 pod 'react-native-webrtc', :path => '../node_modules/react-native-webrtc'
 ```
 
+You may have to change the `platform` field in your Podfile, as `react-native-webrtc` doesn't support iOS 9 - set it to '10.0' or above (otherwise you get an error when doing `pod install`):
+
+```
+platform :ios, '10.0'
+```
+
 ## Step 2. Add Library Search Path
 
 2-1.) select `Build Settings`, find `Search Paths`  


### PR DESCRIPTION
The default react native project (created with `react-native init`) has in the generated Podfile: `platform :ios, '9.0'.
When doing `pod install` during `react-native-webrtc` installation, this gives the error:
```
[!] CocoaPods could not find compatible versions for pod "react-native-webrtc":
  In Podfile:
    react-native-webrtc (from `../node_modules/react-native-webrtc`)

Specs satisfying the `react-native-webrtc (from `../node_modules/react-native-webrtc`)` dependency were found, but they required a higher minimum deployment target.
```
Bumping the iOS version number to `10.0` fixes this error.