### PR TITLE
Expose registerGlobals()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ import {
   RTCView,
   MediaStream,
   MediaStreamTrack,
-  mediaDevices
+  mediaDevices,
+  registerGlobals
 } from 'react-native-webrtc';
 ```
 Anything about using RTCPeerConnection, RTCSessionDescription and RTCIceCandidate is like browser.
@@ -115,6 +116,22 @@ Rendering RTCView.
 
 
 ### Custom APIs
+
+#### registerGlobals()
+
+By calling this method the JavaScript global namespace gets "polluted" with the following additions:
+
+* `navigator.getUserMedia()` (deprecated W3 API)
+* `navigator.mediaDevices.getUserMedia()`
+* `navigator.mediaDevices.enumerateDevices()`
+* `window.RTCPeerConnection`
+* `window.RTCIceCandidate`
+* `window.RTCSessionDescription`
+* `window.MediaStream`
+* `window.MediaStreamTrack`
+
+This is useful to make existing WebRTC JavaScript libraries (that expect those globals to exist) work with react-native-webrtc.
+
 
 #### MediaStreamTrack.prototype._switchCamera()
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Rendering RTCView.
 
 By calling this method the JavaScript global namespace gets "polluted" with the following additions:
 
-* `navigator.getUserMedia()` (deprecated W3 API)
 * `navigator.mediaDevices.getUserMedia()`
 * `navigator.mediaDevices.enumerateDevices()`
 * `window.RTCPeerConnection`

--- a/index.js
+++ b/index.js
@@ -17,5 +17,33 @@ export {
   MediaStream,
   MediaStreamTrack,
   mediaDevices,
-  permissions
+  permissions,
+  registerGlobals
 };
+
+function registerGlobals() {
+	// Should not happen. React Native has a global navigator object.
+	if (typeof navigator !== 'object') {
+		throw new Error('navigator is not an object');
+	}
+
+	if (!navigator.mediaDevices) {
+		navigator.mediaDevices = {};
+	}
+
+	// Deprecated API.
+	navigator.getUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
+
+	// New API.
+	navigator.mediaDevices.getUserMedia =
+		mediaDevices.getUserMedia.bind(mediaDevices);
+
+	navigator.mediaDevices.enumerateDevices =
+		mediaDevices.enumerateDevices.bind(mediaDevices);
+
+	global.RTCPeerConnection     = RTCPeerConnection;
+	global.RTCIceCandidate       = RTCIceCandidate;
+	global.RTCSessionDescription = RTCSessionDescription;
+	global.MediaStream           = MediaStream;
+	global.MediaStreamTrack      = MediaStreamTrack;
+}

--- a/index.js
+++ b/index.js
@@ -31,10 +31,6 @@ function registerGlobals() {
 		navigator.mediaDevices = {};
 	}
 
-	// Deprecated API.
-	navigator.getUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
-
-	// New API.
 	navigator.mediaDevices.getUserMedia =
 		mediaDevices.getUserMedia.bind(mediaDevices);
 


### PR DESCRIPTION
#### registerGlobals()

By calling this method the JavaScript global namespace gets "polluted" with the following additions:

* `navigator.getUserMedia()` (deprecated W3 API)
* `navigator.mediaDevices.getUserMedia()`
* `navigator.mediaDevices.enumerateDevices()`
* `window.RTCPeerConnection`
* `window.RTCIceCandidate`
* `window.RTCSessionDescription`
* `window.MediaStream`
* `window.MediaStreamTrack`

This is useful to make existing WebRTC JavaScript libraries (that expect those globals to exist) work with react-native-webrtc.

It fixes #685