### PR TITLE
Add onFirstFrame callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Rendering RTCView.
 | objectFit                      | string           | 'contain'           | Can be contain or cover                                                                                                | 
 | streamURL                      | string           | ''                  | This is mandatory                                                                                                                      |
 | zOrder                         | number           | 0                   | Similarly to zIndex                                                                                              |
+| onFirstFrame                   | function         | noop                | Is invoked when first video frame is received  
 
 
 ### Custom APIs

--- a/RTCView.js
+++ b/RTCView.js
@@ -66,6 +66,7 @@ const View = requireNativeComponent('RTCVideoView', RTCView, {nativeOnly: {
   importantForAccessibility: true,
   onLayout: true,
   nativeID: true,
+  onFirstFrame: true,
 }});
 
 export default View;

--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -1,6 +1,12 @@
 package com.oney.WebRTCModule;
 
+import com.facebook.react.bridge.ReactContext;
+import java.util.Map;
+
+import android.support.annotation.Nullable;
+
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
@@ -18,6 +24,13 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
     return new WebRTCView(context);
   }
 
+  @Override
+  public @Nullable Map getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.of(
+            "onFirstFrame",
+            MapBuilder.of("registrationName", "onFirstFrame")
+    );
+  }
   /**
    * Sets the indicator which determines whether a specific {@link WebRTCView}
    * is to mirror the video specified by {@code streamURL} during its rendering.

--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -1,9 +1,6 @@
 package com.oney.WebRTCModule;
 
-import com.facebook.react.bridge.ReactContext;
 import java.util.Map;
-
-import android.support.annotation.Nullable;
 
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.common.MapBuilder;
@@ -25,7 +22,7 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
   }
 
   @Override
-  public @Nullable Map getExportedCustomDirectEventTypeConstants() {
+  public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
     return MapBuilder.of(
             "onFirstFrame",
             MapBuilder.of("registrationName", "onFirstFrame")

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Point;
+import android.graphics.Color;
 import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewGroup;
@@ -23,6 +24,12 @@ import org.webrtc.RendererCommon.RendererEvents;
 import org.webrtc.RendererCommon.ScalingType;
 import org.webrtc.SurfaceViewRenderer;
 import org.webrtc.VideoTrack;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class WebRTCView extends ViewGroup {
     /**
@@ -284,9 +291,20 @@ public class WebRTCView extends ViewGroup {
      * rendered) shines through.
      */
     private void onFirstFrameRendered() {
-        post(() -> {
-            Log.d(TAG, "First frame rendered.");
-            surfaceViewRenderer.setBackgroundColor(Color.TRANSPARENT);
+        post(new Runnable() {
+            @Override
+            public void run() {
+                Log.d(TAG, "First frame rendered.");
+
+                WritableMap event = Arguments.createMap();
+                ReactContext reactContext = (ReactContext) getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+                        getId(),
+                        "onFirstFrame",
+                        event
+                );
+                getSurfaceViewRenderer().setBackgroundColor(Color.TRANSPARENT);
+            }
         });
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -291,20 +291,16 @@ public class WebRTCView extends ViewGroup {
      * rendered) shines through.
      */
     private void onFirstFrameRendered() {
-        post(new Runnable() {
-            @Override
-            public void run() {
-                Log.d(TAG, "First frame rendered.");
-
-                WritableMap event = Arguments.createMap();
-                ReactContext reactContext = (ReactContext) getContext();
-                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-                        getId(),
-                        "onFirstFrame",
-                        event
-                );
-                getSurfaceViewRenderer().setBackgroundColor(Color.TRANSPARENT);
-            }
+        post(() -> {
+            Log.d(TAG, "First frame rendered.");
+            WritableMap event = Arguments.createMap();
+            ReactContext reactContext = (ReactContext) getContext();
+            reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+                    getId(),
+                    "onFirstFrame",
+                    event
+            );
+            surfaceViewRenderer.setBackgroundColor(Color.TRANSPARENT);
         });
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -24,10 +24,6 @@ import org.webrtc.RendererCommon.ScalingType;
 import org.webrtc.SurfaceViewRenderer;
 import org.webrtc.VideoTrack;
 
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class WebRTCView extends ViewGroup {

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Point;
-import android.graphics.Color;
 import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewGroup;
@@ -293,12 +292,11 @@ public class WebRTCView extends ViewGroup {
     private void onFirstFrameRendered() {
         post(() -> {
             Log.d(TAG, "First frame rendered.");
-            WritableMap event = Arguments.createMap();
             ReactContext reactContext = (ReactContext) getContext();
             reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
                     getId(),
                     "onFirstFrame",
-                    event
+                    null
             );
             surfaceViewRenderer.setBackgroundColor(Color.TRANSPARENT);
         });

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -282,7 +282,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  */
 - (void)renderFrame:(RTCVideoFrame *)frame {
     id<RTCVideoRenderer> videoRenderer = self.videoView;
-    if (!firstFrameRendered) {
+    if (self.onFirstFrame && !firstFrameRendered) {
       firstFrameRendered = YES;
       self.onFirstFrame(@{});
     }

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  * Implements an equivalent of {@code HTMLVideoElement} i.e. Web's video
  * element.
  */
-@interface RTCVideoView : UIView <RTCVideoViewDelegate>
+@interface RTCVideoView : UIView <RTCVideoRenderer, RTCVideoViewDelegate>
 
 /**
  * The indicator which determines whether this {@code RTCVideoView} is to mirror
@@ -60,6 +60,8 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  * the CSS style {@code object-fit}.
  */
 @property (nonatomic) RTCVideoViewObjectFit objectFit;
+
+@property (nonatomic, copy) RCTDirectEventBlock onFirstFrame;
 
 /**
  * The {@link RRTCVideoRenderer} which implements the actual rendering and which
@@ -85,6 +87,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
    * The width and height of the video (frames) rendered by {@link #subview}.
    */
   CGSize _videoSize;
+  BOOL firstFrameRendered;
 }
 
 @synthesize videoView = _videoView;
@@ -93,6 +96,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  * Tells this view that its window object changed.
  */
 - (void)didMoveToWindow {
+  firstFrameRendered = NO;
   // XXX This RTCVideoView strongly retains its videoTrack. The latter strongly
   // retains the former as well though because RTCVideoTrack strongly retains
   // the RTCVideoRenderers added to it. In other words, there is a cycle of
@@ -104,11 +108,11 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
   if (videoTrack) {
     if (self.window) {
       dispatch_async(_module.workerQueue, ^{
-        [videoTrack addRenderer:self.videoView];
+        [videoTrack addRenderer:self];
       });
     } else {
       dispatch_async(_module.workerQueue, ^{
-        [videoTrack removeRenderer:self.videoView];
+        [videoTrack removeRenderer:self];
       });
       _videoSize.height = 0;
       _videoSize.width = 0;
@@ -246,7 +250,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
   if (oldValue != videoTrack) {
     if (oldValue) {
       dispatch_async(_module.workerQueue, ^{
-        [oldValue removeRenderer:self.videoView];
+        [oldValue removeRenderer:self];
       });
       _videoSize.height = 0;
       _videoSize.width = 0;
@@ -263,10 +267,40 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
     // of its videoTrack only while this view resides in a window.
     if (videoTrack && self.window) {
         dispatch_async(_module.workerQueue, ^{
-            [videoTrack addRenderer:self.videoView];
+            [videoTrack addRenderer:self];
         });
     }
   }
+}
+#pragma mark - RTCVideoRenderer methods
+
+/**
+ * Renders a specific video frame. Delegates to the subview of this instance
+ * which implements the actual {@link RTCVideoRenderer}.
+ *
+ * @param frame The video frame to render.
+ */
+- (void)renderFrame:(RTCVideoFrame *)frame {
+    id<RTCVideoRenderer> videoRenderer = self.videoView;
+    if (!firstFrameRendered) {
+      firstFrameRendered = YES;
+      self.onFirstFrame(@{});
+    }
+    if (videoRenderer) {
+      [videoRenderer renderFrame:frame];
+    }
+}
+
+/**
+ * Sets the size of the video frame to render.
+ *
+ * @param size The size of the video frame to render.
+ */
+- (void)setSize:(CGSize)size {
+    id<RTCVideoRenderer> videoRenderer = self.videoView;
+    if (videoRenderer) {
+        [videoRenderer setSize:size];
+    }
 }
 
 #pragma mark - RTCVideoViewDelegate methods
@@ -293,6 +327,8 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
 @implementation RTCVideoViewManager
 
 RCT_EXPORT_MODULE()
+
+RCT_EXPORT_VIEW_PROPERTY(onFirstFrame, RCTDirectEventBlock)
 
 - (UIView *)view {
   RTCVideoView *v = [[RTCVideoView alloc] init];


### PR DESCRIPTION
This PR fixes https://github.com/react-native-webrtc/react-native-webrtc/issues/679 by adding `onFirstFrame` callback, which fires when first video frame is received. 
Note, however, that audio stream can start playing earlier.