### PR TITLE
MediaStream remote track support

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -509,7 +509,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
     private void mediaStreamAddTrackAsync(String streamId, String trackId) {
         MediaStream stream = localStreams.get(streamId);
-        MediaStreamTrack track = getLocalTrack(trackId);
+        MediaStreamTrack track = getTrack(trackId);
 
         if (stream == null || track == null) {
             Log.d(TAG, "mediaStreamAddTrack() stream || track is null");
@@ -532,7 +532,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
     private void mediaStreamRemoveTrackAsync(String streamId, String trackId) {
         MediaStream stream = localStreams.get(streamId);
-        MediaStreamTrack track = getLocalTrack(trackId);
+        MediaStreamTrack track = getTrack(trackId);
 
         if (stream == null || track == null) {
             Log.d(TAG, "mediaStreamRemoveTrack() stream || track is null");

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -161,7 +161,7 @@ RCT_EXPORT_METHOD(mediaStreamCreate:(nonnull NSString *)streamID)
 RCT_EXPORT_METHOD(mediaStreamAddTrack:(nonnull NSString *)streamID : (nonnull NSString *)trackID)
 {
     RTCMediaStream *mediaStream = self.localStreams[streamID];
-    RTCMediaStreamTrack *track = self.localTracks[trackID];
+    RTCMediaStreamTrack *track = [self trackForId:trackID];
 
     if (mediaStream && track) {
         if ([track.kind isEqualToString:@"audio"]) {
@@ -175,7 +175,7 @@ RCT_EXPORT_METHOD(mediaStreamAddTrack:(nonnull NSString *)streamID : (nonnull NS
 RCT_EXPORT_METHOD(mediaStreamRemoveTrack:(nonnull NSString *)streamID : (nonnull NSString *)trackID)
 {
     RTCMediaStream *mediaStream = self.localStreams[streamID];
-    RTCMediaStreamTrack *track = self.localTracks[trackID];
+    RTCMediaStreamTrack *track = [self trackForId:trackID];
 
     if (mediaStream && track) {
         if ([track.kind isEqualToString:@"audio"]) {


### PR DESCRIPTION
MediaStream `addTrack` and `removeTrack` needs to include remote tracks. 

This is needed to support MediaSoup. Fixes issues #717 and #718.