### PR TITLE
fix: ios data channel

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -386,7 +386,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
       // is reserved due to SCTP INIT and INIT-ACK chunks only allowing a
       // maximum of 65535 streams to be negotiated (as defined by the WebRTC
       // Data Channel Establishment Protocol).
-      for (id = 0; id < 65535 && dataChannelIds.has(id); ++id);
+      for (id = 1; id < 65535 && dataChannelIds.has(id); ++id);
       // TODO Throw an error if no unused id is available.
       dataChannelDict = Object.assign({id}, dataChannelDict);
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
@@ -29,12 +29,10 @@ RCT_EXPORT_METHOD(createDataChannel:(nonnull NSNumber *)peerConnectionId
 {
   RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
   RTCDataChannel *dataChannel = [peerConnection dataChannelForLabel:label configuration:config];
-  // XXX RTP data channels are not defined by the WebRTC standard, have been
-  // deprecated in Chromium, and Google have decided (in 2015) to no longer
-  // support them (in the face of multiple reported issues of breakages).
-  if (-1 != dataChannel.channelId) {
+  if (dataChannel != nil && (dataChannel.readyState == RTCDataChannelStateConnecting
+      || dataChannel.readyState == RTCDataChannelStateOpen)) {
     dataChannel.peerConnectionId = peerConnectionId;
-    NSNumber *dataChannelId = [NSNumber numberWithInteger:dataChannel.channelId];
+    NSNumber *dataChannelId = [NSNumber numberWithInteger:config.channelId];
     peerConnection.dataChannels[dataChannelId] = dataChannel;
     dataChannel.delegate = self;
   }


### PR DESCRIPTION
dataChannel.channelId is always equal to -1 while connecting. 
If create data channel with id 0 then it is not work on ios

