### PR TITLE
POC: android: support snapshot through RTCView via SurfaceViewRenderer

### DIFF
--- a/RTCView.js
+++ b/RTCView.js
@@ -53,7 +53,8 @@ const RTCView = {
      * remote video(s) which appear in the background, and 1 for the local
      * video(s) which appear above the remote video(s).
      */
-    zOrder: PropTypes.number
+    zOrder: PropTypes.number,
+    snapshotOption: PropTypes.object,
   },
 };
 

--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -1,5 +1,8 @@
 package com.oney.WebRTCModule;
 
+import android.support.annotation.Nullable;
+
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -70,5 +73,18 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
   @ReactProp(name = "zOrder")
   public void setZOrder(WebRTCView view, int zOrder) {
     view.setZOrder(zOrder);
+  }
+
+  /**
+   * Take a snapshot of a specific {@link WebRTCView}
+   *
+   * @param view The {@code WebRTCView} on which the specified {@code option} is
+   * to be set.
+   * @param snapshotOption Represent each unique snapshot action, everytime the option changes,
+   * will triiger one snapshot.
+   */
+  @ReactProp(name = "snapshotOption")
+  public void handleTakeSnapshot(WebRTCView view, @Nullable ReadableMap snapshotOption) {
+    view.handleTakeSnapshot(snapshotOption);
   }
 }

--- a/android/src/main/java/com/oney/WebRTCModule/SnapshotUtils.java
+++ b/android/src/main/java/com/oney/WebRTCModule/SnapshotUtils.java
@@ -1,0 +1,161 @@
+package com.oney.WebRTCModule;
+
+import com.facebook.react.bridge.ReactContext;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.graphics.Rect;
+import android.media.MediaScannerConnection;
+import android.net.Uri;
+import android.os.Environment;
+import android.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import java.util.Base64;
+import java.util.UUID;
+
+class SnapshotUtils {
+    private static final String TAG = WebRTCModule.TAG;
+
+    public static final String RCT_CAMERA_SAVE_TARGET_MEMORY = "memory";
+    public static final String RCT_CAMERA_SAVE_TARGET_DISK = "disk";
+    public static final String RCT_CAMERA_SAVE_TARGET_CAMERA_ROLL = "cameraRoll";
+    public static final String RCT_CAMERA_SAVE_TARGET_TEMP = "temp";
+
+    public static String encodeToBase64String(byte[] pic) {
+        return Base64.getEncoder().encodeToString(pic);
+    }
+
+    public static synchronized String savePicture(ReactContext reactContext, Bitmap bitmap, String saveTarget, double maxJpegQuality, int maxSize) throws IOException {
+        // --- only resize if image larger than maxSize
+        bitmap = resizeBitmap(bitmap, maxSize);
+        int jpegQuality = (int) (100 * maxJpegQuality);
+
+        String filename = UUID.randomUUID().toString();
+        File file = null;
+        switch (saveTarget) {
+            case RCT_CAMERA_SAVE_TARGET_CAMERA_ROLL: {
+                file = getOutputCameraRollFile(filename);
+                writePictureToFile(bitmap, file, jpegQuality);
+                addToMediaStore(reactContext, file.getAbsolutePath());
+                break;
+            }
+            case RCT_CAMERA_SAVE_TARGET_DISK: {
+                file = getOutputMediaFile(filename);
+                writePictureToFile(bitmap, file, jpegQuality);
+                break;
+            }
+            case RCT_CAMERA_SAVE_TARGET_TEMP: {
+                file = getTempMediaFile(reactContext, filename);
+                writePictureToFile(bitmap, file, jpegQuality);
+                break;
+            }
+            default: {
+                // --- memory
+                ByteArrayOutputStream stream = new ByteArrayOutputStream();
+                bitmap.compress(Bitmap.CompressFormat.JPEG, jpegQuality, stream);
+                byte[] jpeg = stream.toByteArray();
+                return encodeToBase64String(jpeg);
+            }
+        }
+        return Uri.fromFile(file).toString();
+    }
+
+    public static Bitmap resizeBitmap(Bitmap bitmap, int maxSize) {
+        int width = bitmap.getWidth();
+        int height = bitmap.getHeight();
+        // only resize if image larger than maxSize
+        if (width > maxSize && height > maxSize) {
+            Matrix matrix = new Matrix();
+            Rect originalRect = new Rect(0, 0, width, height);
+            Rect scaledRect = scaleDimension(originalRect, maxSize);
+            Log.d(TAG, "scaled width = " + scaledRect.width() + ", scaled height = " + scaledRect.height());
+            // calculate the scale
+            float scaleWidth = ((float) scaledRect.width()) / width;
+            float scaleHeight = ((float) scaledRect.height()) / height;
+            matrix.postScale(scaleWidth, scaleHeight);
+            bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+        }
+
+        return bitmap;
+    }
+
+    public static String writePictureToFile(Bitmap bitmap, File file, int jpegQuality) throws IOException {
+        FileOutputStream finalOutput = new FileOutputStream(file, false);
+        bitmap.compress(Bitmap.CompressFormat.JPEG, jpegQuality, finalOutput);
+        finalOutput.close();
+        return file.getAbsolutePath();
+    }
+
+    public static File getOutputMediaFile(String fileName) {
+        // Get environment directory type id from requested media type.
+        String environmentDirectoryType;
+        environmentDirectoryType = Environment.DIRECTORY_PICTURES;
+        return getOutputFile(
+                fileName + ".jpeg",
+                Environment.getExternalStoragePublicDirectory(environmentDirectoryType)
+        );
+    }
+
+    public static File getOutputCameraRollFile(String fileName) {
+        return getOutputFile(
+                fileName + ".jpeg",
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
+        );
+    }
+
+    public static File getOutputFile(String fileName, File storageDir) {
+        // Create the storage directory if it does not exist
+        if (!storageDir.exists()) {
+            if (!storageDir.mkdirs()) {
+                Log.e(TAG, "failed to create directory:" + storageDir.getAbsolutePath());
+                return null;
+            }
+        }
+        return new File(String.format("%s%s%s", storageDir.getPath(), File.separator, fileName));
+    }
+
+    public static File getTempMediaFile(ReactContext reactContext, String fileName) {
+        try {
+            File outputDir = reactContext.getCacheDir();
+            File outputFile;
+            outputFile = File.createTempFile(fileName, ".jpg", outputDir);
+            return outputFile;
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage());
+            return null;
+        }
+    }
+
+    public static void addToMediaStore(ReactContext reactContext, String path) {
+        MediaScannerConnection.scanFile(reactContext, new String[]{path}, null, null);
+    }
+
+    public static Rect scaleDimension(Rect originalRect, int maxSize) {
+        int originalWidth = originalRect.width();
+        int originalHeight = originalRect.height();
+        int newWidth = originalWidth;
+        int newHeight = originalHeight;
+        // first check if we need to scale width
+        if (originalWidth > maxSize) {
+            //scale width to fit
+            newWidth = maxSize;
+            //scale height to maintain aspect ratio
+            newHeight = (newWidth * originalHeight) / originalWidth;
+        }
+        // then check if we need to scale even with the new height
+        if (newHeight > maxSize) {
+            //scale height to fit instead
+            newHeight = maxSize;
+            //scale width to maintain aspect ratio
+            newWidth = (newHeight * originalWidth) / originalHeight;
+        }
+        return new Rect(0, 0, newWidth, newHeight);
+    }
+
+}


### PR DESCRIPTION
## Motivation

There has been several discussions and implementations since 2016, see #176
But it needs to patch the underling webrtc build, and only works for local stream (through camera api)

On android, this PR can take snapshot use `onFrame`, so it support both `local` and `remote` stream. To be accurate, it catches video frame from RTCView, and the api invocation is based on each RTCView as well.

Thanks to all contributors in #176 
Especially @davidperrenoud and @EdwarDu
The `SnapshotUtils.java` are credit to the original author.

**Note: I haven't test in detail for every saveTarget and resize part (`maxSize`)**

This PR is a POC and mainly for discussion and test.

## How this PR works

We can add `onFrame` listener to `SurfaceViewRenderer` of  specific `RTCView`, and the event contains Bitmap, which is what we want.

#### see below critical part of codes:

```java
surfaceViewRenderer.addFrameListener(new EglRenderer.FrameListener() {
    @Override
    public void onFrame(Bitmap bitmap) {
        try {
            // --- default is convert to jpeg and save to cameraRoll
        } finally {
            // --- remove listener immediately
            surfaceViewRenderer.removeFrameListener(this);
            // --- send result to js
            module.sendEvent("WebRTCViewSnapshotResult", params);
        }
    }
}, 1);
```

## API differences

AFAIK, the method used in this PR does not exist on iOS, so the two platform might using different approach.

* on android: catch frame from RTCView ( RTCView only )
* on ios: use `react-native-view-shot` ( full screen, like phone's embedded hardware screenshot )

So on ios, if you want only screenshot for specific RTCView, you might need to hide other components yourself.

## Combined Usage Example For Android / iOS

This example only cares about take snapshot for REMOTE Peer

**Note: you need to handle correspond permissions yourself depends on your `saveTarget`**

```js
class CallView extends React.Component {

    constructor(props) {
        this.state = {
            // --- for android to trigger snapshot on remote RTCView
            remoteVideoViewSnapshotOption: null,
            // --- for ios to control whether should render full screen remote view
            hideAllViewExceptRemoteRTCView: false,
        }
    }

    componentDidMount() {
            DeviceEventEmitter.addListener('WebRTCViewSnapshotResult', this.onWebRTCViewSnapshotResult);
    }

    componentWillUnmount() {
            DeviceEventEmitter.removeAllListeners('WebRTCViewSnapshotResult');
    }

    onWebRTCViewSnapshotResult(data) {
        // --- reset option after we got event. It's okey to not reset, since it will trigger a new screenshot as long as props did change again. (likely use shallow compare.)
        this.setState({ remoteVideoViewSnapshotOption: null });
        if (data.error) {
            // --- failed
        }
        if (data.file) {
            // --- saved file path
        }
    }

    async onPressTakeSnapshot() {
        if (PlatformOS.platform === 'android') {
                // --- check required permission, in the case of cameraRoll, you need: READ/WRITE EXTERNAL STORAGE permission
                let hasEnoughPermission = await checkScreenshotPermission();
                if (!hasEnoughPermission) {
                    return false;
                }
                // --- if snapshotOption != null and changed, the remote RTCView will trigger snapshot once and fire an event for result.
                let snapshotOption = {
                    id: uuid.v4(), // --- use any value you think it's unique for each screenshot
                    saveTarget: 'cameraRoll',
                };
                this.setState({ remoteVideoViewSnapshotOption: snapshotOption });
        } else {
            // IOS
            // --- optional: if you want full screen remote view only, take snapshot after you've adjust your views
            this.setState({ hideAllViewExceptRemoteRTCView: true }, async () => {
                    captureScreen = require("react-native-view-shot").captureScreen;
                    CameraRoll = require("@react-native-community/cameraroll");

                    let uriCache = await captureScreen({ format: 'jpg' });
                    if (!uriCache) {
                        return false;
                    }
                    let uriSaved = CameraRoll.saveToCameraRoll(uriCacheRenamed, 'photo');

                    // --- optional: recover your view setup
                    this.setState({ hideAllViewExceptRemoteRTCView: false });
            }
        }
    }

    render() {
        if (this.state.hideAllViewExceptRemoteRTCView) {
            // --- style is for iOS return full screen remote view
            // --- snapshotOption is for android to trigger snapshot
            return (
                 <RTCView
                      streamURL={streamUrl}
                      style={styles.fullScreen}
                      snapshotOption={(streamUrl ? this.state.snapshotOption : null)}
                 />
            );
        } else {
            // --- return (.....full call view setup)
        }
    }
```

## Discussion

I know it's a bit strange to use props to trigger like a function.
But we can not get RTCView instance from module currently. ( And I am not sure what is the proper way for doing so )

If we can store RTCView ID on native side, we might endup have below more intuitive api, like:


* `WebRTC.takeSnapshot(viewId)`
or
* `videoTrack.takeSnapshot()`, and find the corresponded RTCView id at native side 
