### PR TITLE
Use NativeEventEmitter instead of DeviceEventEmitter

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -1,0 +1,7 @@
+import {NativeModules, NativeEventEmitter} from 'react-native';
+
+const { WebRTCModule } = NativeModules;
+
+const EventEmitter = new NativeEventEmitter(WebRTCModule);
+
+export default EventEmitter;

--- a/RTCDataChannel.js
+++ b/RTCDataChannel.js
@@ -1,10 +1,11 @@
 'use strict';
 
-import {NativeModules, DeviceEventEmitter} from 'react-native';
+import { NativeModules } from 'react-native';
 import base64 from 'base64-js';
 import EventTarget from 'event-target-shim';
 import MessageEvent from './MessageEvent';
 import RTCDataChannelEvent from './RTCDataChannelEvent';
+import EventEmitter from './EventEmitter';
 
 const {WebRTCModule} = NativeModules;
 
@@ -116,7 +117,7 @@ export default class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
 
   _registerEvents() {
     this._subscriptions = [
-      DeviceEventEmitter.addListener('dataChannelStateChanged', ev => {
+      EventEmitter.addListener('dataChannelStateChanged', ev => {
         if (ev.peerConnectionId !== this._peerConnectionId
             || ev.id !== this.id) {
           return;
@@ -129,7 +130,7 @@ export default class RTCDataChannel extends EventTarget(DATA_CHANNEL_EVENTS) {
           this._unregisterEvents();
         }
       }),
-      DeviceEventEmitter.addListener('dataChannelReceiveMessage', ev => {
+      EventEmitter.addListener('dataChannelReceiveMessage', ev => {
         if (ev.peerConnectionId !== this._peerConnectionId
             || ev.id !== this.id) {
           return;

--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import EventTarget from 'event-target-shim';
-import {DeviceEventEmitter, NativeModules} from 'react-native';
+import { NativeModules, NativeEventEmitter } from 'react-native';
 
 import MediaStream from './MediaStream';
 import MediaStreamEvent from './MediaStreamEvent';
@@ -14,6 +14,7 @@ import RTCIceCandidate from './RTCIceCandidate';
 import RTCIceCandidateEvent from './RTCIceCandidateEvent';
 import RTCEvent from './RTCEvent';
 import * as RTCUtil from './RTCUtil';
+import EventEmitter from './EventEmitter';
 
 const {WebRTCModule} = NativeModules;
 
@@ -249,13 +250,13 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
 
   _registerEvents(): void {
     this._subscriptions = [
-      DeviceEventEmitter.addListener('peerConnectionOnRenegotiationNeeded', ev => {
+      EventEmitter.addListener('peerConnectionOnRenegotiationNeeded', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
         this.dispatchEvent(new RTCEvent('negotiationneeded'));
       }),
-      DeviceEventEmitter.addListener('peerConnectionIceConnectionChanged', ev => {
+      EventEmitter.addListener('peerConnectionIceConnectionChanged', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
@@ -266,14 +267,14 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
           this._unregisterEvents();
         }
       }),
-      DeviceEventEmitter.addListener('peerConnectionSignalingStateChanged', ev => {
+      EventEmitter.addListener('peerConnectionSignalingStateChanged', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
         this.signalingState = ev.signalingState;
         this.dispatchEvent(new RTCEvent('signalingstatechange'));
       }),
-      DeviceEventEmitter.addListener('peerConnectionAddedStream', ev => {
+      EventEmitter.addListener('peerConnectionAddedStream', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
@@ -281,7 +282,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
         this._remoteStreams.push(stream);
         this.dispatchEvent(new MediaStreamEvent('addstream', {stream}));
       }),
-      DeviceEventEmitter.addListener('peerConnectionRemovedStream', ev => {
+      EventEmitter.addListener('peerConnectionRemovedStream', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
@@ -294,7 +295,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
         }
         this.dispatchEvent(new MediaStreamEvent('removestream', {stream}));
       }),
-      DeviceEventEmitter.addListener('mediaStreamTrackMuteChanged', ev => {
+      EventEmitter.addListener('mediaStreamTrackMuteChanged', ev => {
         if (ev.peerConnectionId !== this._peerConnectionId) {
           return;
         }
@@ -305,7 +306,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
           track.dispatchEvent(new MediaStreamTrackEvent(eventName, {track}));
         }
       }),
-      DeviceEventEmitter.addListener('peerConnectionGotICECandidate', ev => {
+      EventEmitter.addListener('peerConnectionGotICECandidate', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
@@ -313,7 +314,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
         const event = new RTCIceCandidateEvent('icecandidate', {candidate});
         this.dispatchEvent(event);
       }),
-      DeviceEventEmitter.addListener('peerConnectionIceGatheringChanged', ev => {
+      EventEmitter.addListener('peerConnectionIceGatheringChanged', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }
@@ -325,7 +326,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
 
         this.dispatchEvent(new RTCEvent('icegatheringstatechange'));
       }),
-      DeviceEventEmitter.addListener('peerConnectionDidOpenDataChannel', ev => {
+      EventEmitter.addListener('peerConnectionDidOpenDataChannel', ev => {
         if (ev.id !== this._peerConnectionId) {
           return;
         }

--- a/RTCView.js
+++ b/RTCView.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import {
-  DeviceEventEmitter,
   NativeModules,
   requireNativeComponent,
 } from 'react-native';

--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
@@ -81,8 +81,7 @@ RCT_EXPORT_METHOD(dataChannelSend:(nonnull NSNumber *)peerConnectionId
   NSDictionary *event = @{@"id": @(channel.channelId),
                           @"peerConnectionId": channel.peerConnectionId,
                           @"state": [self stringForDataChannelState:channel.readyState]};
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"dataChannelStateChanged"
-                                                  body:event];
+  [self sendEventWithName:kEventDataChannelStateChanged body:event];
 }
 
 // Called when a data buffer was successfully received.
@@ -111,8 +110,7 @@ RCT_EXPORT_METHOD(dataChannelSend:(nonnull NSNumber *)peerConnectionId
                           // unacceptable given that protection in such a
                           // scenario is extremely simple.
                           @"data": (data ? data : [NSNull null])};
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"dataChannelReceiveMessage"
-                                                  body:event];
+  [self sendEventWithName:kEventDataChannelReceiveMessage body:event];
 }
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -413,8 +413,11 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
 #pragma mark - RTCPeerConnectionDelegate methods
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeSignalingState:(RTCSignalingState)newState {
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionSignalingStateChanged" body:
-   @{@"id": peerConnection.reactTag, @"signalingState": [self stringForSignalingState:newState]}];
+  [self sendEventWithName:kEventPeerConnectionSignalingStateChanged
+                     body:@{
+                       @"id": peerConnection.reactTag,
+                       @"signalingState": [self stringForSignalingState:newState]
+                     }];
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didAddStream:(RTCMediaStream *)stream {
@@ -431,8 +434,13 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
   }
 
   peerConnection.remoteStreams[streamReactTag] = stream;
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionAddedStream"
-                                                  body:@{@"id": peerConnection.reactTag, @"streamId": stream.streamId, @"streamReactTag": streamReactTag, @"tracks": tracks}];
+  [self sendEventWithName:kEventPeerConnectionAddedStream
+                     body:@{
+                       @"id": peerConnection.reactTag,
+                       @"streamId": stream.streamId,
+                       @"streamReactTag": streamReactTag,
+                       @"tracks": tracks
+                     }];
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didRemoveStream:(RTCMediaStream *)stream {
@@ -459,28 +467,44 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
     [peerConnection.remoteTracks removeObjectForKey:track.trackId];
   }
   [peerConnection.remoteStreams removeObjectForKey:streamReactTag];
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionRemovedStream" body:
-   @{@"id": peerConnection.reactTag, @"streamId": streamReactTag}];
+  [self sendEventWithName:kEventPeerConnectionRemovedStream
+                     body:@{
+                       @"id": peerConnection.reactTag,
+                       @"streamId": streamReactTag
+                     }];
 }
 
 - (void)peerConnectionShouldNegotiate:(RTCPeerConnection *)peerConnection {
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionOnRenegotiationNeeded" body:
-   @{@"id": peerConnection.reactTag}];
+  [self sendEventWithName:kEventPeerConnectionOnRenegotiationNeeded
+                     body:@{ @"id": peerConnection.reactTag }];
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeIceConnectionState:(RTCIceConnectionState)newState {
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionIceConnectionChanged" body:
-   @{@"id": peerConnection.reactTag, @"iceConnectionState": [self stringForICEConnectionState:newState]}];
+  [self sendEventWithName:kEventPeerConnectionIceConnectionChanged
+                     body:@{
+                       @"id": peerConnection.reactTag,
+                       @"iceConnectionState": [self stringForICEConnectionState:newState]
+                     }];
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeIceGatheringState:(RTCIceGatheringState)newState {
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionIceGatheringChanged" body:
-   @{@"id": peerConnection.reactTag, @"iceGatheringState": [self stringForICEGatheringState:newState]}];
+  [self sendEventWithName:kEventPeerConnectionIceGatheringChanged
+                     body:@{
+                       @"id": peerConnection.reactTag,
+                       @"iceGatheringState": [self stringForICEGatheringState:newState]
+                     }];
 }
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didGenerateIceCandidate:(RTCIceCandidate *)candidate {
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionGotICECandidate" body:
-   @{@"id": peerConnection.reactTag, @"candidate": @{@"candidate": candidate.sdp, @"sdpMLineIndex": @(candidate.sdpMLineIndex), @"sdpMid": candidate.sdpMid}}];
+  [self sendEventWithName:kEventPeerConnectionGotICECandidate
+                     body:@{
+                       @"id": peerConnection.reactTag,
+                       @"candidate": @{
+                           @"candidate": candidate.sdp,
+                           @"sdpMLineIndex": @(candidate.sdpMLineIndex),
+                           @"sdpMid": candidate.sdpMid
+                       }
+                     }];
 }
 
 - (void)peerConnection:(RTCPeerConnection*)peerConnection didOpenDataChannel:(RTCDataChannel*)dataChannel {
@@ -501,8 +525,7 @@ RCT_EXPORT_METHOD(peerConnectionGetStats:(nonnull NSString *)trackID
   NSDictionary *body = @{@"id": peerConnection.reactTag,
                         @"dataChannel": @{@"id": dataChannelId,
                                           @"label": dataChannel.label}};
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionDidOpenDataChannel"
-                                                  body:body];
+  [self sendEventWithName:kEventPeerConnectionDidOpenDataChannel body:body];
 }
 
 - (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didRemoveIceCandidates:(nonnull NSArray<RTCIceCandidate *> *)candidates {

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
@@ -71,12 +71,13 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
 }
 
 - (void)emitMuteEvent:(BOOL)muted {
-    [self.module.bridge.eventDispatcher
-        sendDeviceEventWithName:@"mediaStreamTrackMuteChanged"
-                   body:@{@"peerConnectionId": self.peerConnectionId,
-                          @"streamReactTag": self.streamReactTag,
-                          @"trackId": self.trackId,
-                          @"muted": @(muted)}];
+    [self.module sendEventWithName:kEventMediaStreamTrackMuteChanged
+                              body:@{
+                                @"peerConnectionId": self.peerConnectionId,
+                                @"streamReactTag": self.streamReactTag,
+                                @"trackId": self.trackId,
+                                @"muted": @(muted)
+                              }];
     RCTLog(@"[VideoTrackAdapter] %@ event for %@ %@ %@",
           muted ? @"Mute" : @"Unmute",
           self.peerConnectionId,

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -10,6 +10,7 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
+#import <React/RCTEventEmitter.h>
 
 #import <WebRTC/RTCMediaStream.h>
 #import <WebRTC/RTCPeerConnectionFactory.h>
@@ -19,7 +20,19 @@
 #import <WebRTC/RTCVideoDecoderFactory.h>
 #import <WebRTC/RTCVideoEncoderFactory.h>
 
-@interface WebRTCModule : NSObject <RCTBridgeModule>
+static NSString *const kEventPeerConnectionSignalingStateChanged = @"peerConnectionSignalingStateChanged";
+static NSString *const kEventPeerConnectionAddedStream = @"peerConnectionAddedStream";
+static NSString *const kEventPeerConnectionRemovedStream = @"peerConnectionRemovedStream";
+static NSString *const kEventPeerConnectionOnRenegotiationNeeded = @"peerConnectionOnRenegotiationNeeded";
+static NSString *const kEventPeerConnectionIceConnectionChanged = @"peerConnectionIceConnectionChanged";
+static NSString *const kEventPeerConnectionIceGatheringChanged = @"peerConnectionIceGatheringChanged";
+static NSString *const kEventPeerConnectionGotICECandidate = @"peerConnectionGotICECandidate";
+static NSString *const kEventPeerConnectionDidOpenDataChannel = @"peerConnectionDidOpenDataChannel";
+static NSString *const kEventDataChannelStateChanged = @"dataChannelStateChanged";
+static NSString *const kEventDataChannelReceiveMessage = @"dataChannelReceiveMessage";
+static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMuteChanged";
+
+@interface WebRTCModule : RCTEventEmitter <RCTBridgeModule>
 
 @property(nonatomic, strong) dispatch_queue_t workerQueue;
 

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -22,8 +22,6 @@
 
 @implementation WebRTCModule
 
-@synthesize bridge = _bridge;
-
 + (BOOL)requiresMainQueueSetup
 {
     return NO;
@@ -98,6 +96,22 @@ RCT_EXPORT_MODULE();
 - (dispatch_queue_t)methodQueue
 {
   return _workerQueue;
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[
+    kEventPeerConnectionSignalingStateChanged,
+    kEventPeerConnectionAddedStream,
+    kEventPeerConnectionRemovedStream,
+    kEventPeerConnectionOnRenegotiationNeeded,
+    kEventPeerConnectionIceConnectionChanged,
+    kEventPeerConnectionIceGatheringChanged,
+    kEventPeerConnectionGotICECandidate,
+    kEventPeerConnectionDidOpenDataChannel,
+    kEventDataChannelStateChanged,
+    kEventDataChannelReceiveMessage,
+    kEventMediaStreamTrackMuteChanged
+  ];
 }
 
 @end


### PR DESCRIPTION
Since `DeviceEventEmitter` is [deprecated](https://github.com/facebook/react-native/blob/1490ab12ef156bf3201882eeabfcac18a1210352/Libraries/EventEmitter/RCTNativeAppEventEmitter.js#L15), this PR switch to use `NativeEventEmitter`

Changes:
1. JS side
- replace `DeviceEventEmitter` with `NativeEventEmitter`
2. iOS native
- extends `RCTEventEmitter`
- use `sendEventWithName` from `RCTEventEmitter` to send event to JS.
