### PR TITLE
Update step 4 to account for autolinking

### DIFF
--- a/Documentation/AndroidInstallation.md
+++ b/Documentation/AndroidInstallation.md
@@ -29,7 +29,7 @@ dependencies {
 
 ```
 
-4.) In `android/app/src/main/java/com/xxx/MainApplication.java`
+4.) In `android/app/src/main/java/com/xxx/MainApplication.java` (When using up-to-date versions of the library, this step can be skipped because the package is autolinked.)
 
 React Native versions 0.60.0 after
 ```java


### PR DESCRIPTION
With autolinking, performing step 4 will result in errors as the package will be loaded twice.