### PR TITLE
ios: Enable camera switching

### DIFF
--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -116,6 +116,7 @@
 
 -(void)switchCamera {
     _usingFrontCamera = !_usingFrontCamera;
+    _deviceId = NULL;
 
     [self startCapture];
 }


### PR DESCRIPTION
If the devices has been requested with the parameter `deviceId` like this `navigator.mediaDevices.getUserMedia({video: {deviceId: 'n'}})` the method `_switchCamera` will not work. Setting the `_deviceId` to `NULL` in the `switchCamera` method will allow the change.