### PR TITLE
Fix Build webrtc using xcode 12

### DIFF
--- a/Documentation/BuildingWebRTC.md
+++ b/Documentation/BuildingWebRTC.md
@@ -46,6 +46,9 @@ cd
 
 Now the code is ready for building!
 
+Notice that since M79 chromium changed the branch naming scheme, for example M87 is WebRTC branch 4280.
+For a full list of branches, see: https://chromiumdash.appspot.com/branches
+
 ## Building
 
 ### iOS

--- a/tools/build-webrtc.py
+++ b/tools/build-webrtc.py
@@ -23,6 +23,9 @@ def build_gn_args(platform_args):
     return "--args='" + ' '.join(GN_COMMON_ARGS + platform_args) + "'"
 
 GN_COMMON_ARGS = [
+    # Xcode 12 Clang consider warning as error by default 
+    # See https://bugs.chromium.org/p/webrtc/issues/detail?id=11729
+    'treat_warnings_as_errors=false',
     'is_component_build=false',
     'rtc_libvpx_build_vp9=true',
     'is_debug=%s',


### PR DESCRIPTION
Since XCode 12 update, it look like by default warnings are treated as errors using clang.

To fix that I confirmed that adding "treat_warnings_as_errors=false" to GN_COMMON_ARGS  does fix the issue to build WebRTC from M69 to M87 for ios and android.

I also upated BuildingWebRTC.md doc to provide reference link to the WebRTC branch names.

Reference:
- https://stackoverflow.com/questions/64111205/enabling-bitcode-for-webrtc-ios
- https://bugs.chromium.org/p/webrtc/issues/detail?id=11729