### PR TITLE
Added an empty object as the default parameter for RTCSessionDescription

### DIFF
--- a/RTCSessionDescription.js
+++ b/RTCSessionDescription.js
@@ -4,7 +4,7 @@ export default class RTCSessionDescription {
   sdp: string;
   type: string;
 
-  constructor(info) {
+  constructor(info = {}) {
     this.sdp = info.sdp;
     this.type = info.type;
   }

--- a/RTCSessionDescription.js
+++ b/RTCSessionDescription.js
@@ -4,7 +4,7 @@ export default class RTCSessionDescription {
   sdp: string;
   type: string;
 
-  constructor(info = {}) {
+  constructor(info = {type: null, sdp: ''}) {
     this.sdp = info.sdp;
     this.type = info.type;
   }


### PR DESCRIPTION
Calling RTCSessionDescription constructor fails, if called with no argument, which is not consistent with current browser behavior.

https://github.com/react-native-webrtc/react-native-webrtc/issues/797