### PR TITLE
Fix crash when originDataChannelId is nil

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
@@ -95,8 +95,10 @@ RCT_EXPORT_METHOD(dataChannelSend:(nonnull NSNumber *)peerConnectionId
 // Called when the data channel state has changed.
 - (void)dataChannelDidChangeState:(RTCDataChannel*)channel
 {
+  NSNumber *id = channel.originDataChannelId ?: @1;
+
   // use originDataChannelId instead of channelId to keep the consistency with JS side
-  NSDictionary *event = @{@"id": channel.originDataChannelId,
+  NSDictionary *event = @{@"id": id,
                           @"peerConnectionId": channel.peerConnectionId,
                           @"state": [self stringForDataChannelState:channel.readyState]};
   [self sendEventWithName:kEventDataChannelStateChanged body:event];
@@ -120,8 +122,11 @@ RCT_EXPORT_METHOD(dataChannelSend:(nonnull NSNumber *)peerConnectionId
     data = [[NSString alloc] initWithData:buffer.data
                                  encoding:NSUTF8StringEncoding];
   }
+
+  NSNumber *id = channel.originDataChannelId ?: @1;
+
   // use originDataChannelId instead of channelId to keep the consistency with JS side
-  NSDictionary *event = @{@"id": channel.originDataChannelId,
+  NSDictionary *event = @{@"id": id,
                           @"peerConnectionId": channel.peerConnectionId,
                           @"type": type,
                           // XXX NSDictionary will crash the process upon


### PR DESCRIPTION
fixes #962

This PR aims to aid the issue that due to some race condition most likely, in some cases (mostly in simulators) datachannel creation can fail because `originDataChannelId` is set to nil and we want to access it, causing a crash. To solve this, in cases like this we just default the id to 1.