### PR TITLE
Allow to retrieve stream from outside

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -414,7 +414,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         mPeerConnectionObservers.put(id, observer);
     }
 
-    MediaStream getStreamForReactTag(String streamReactTag) {
+    public MediaStream getStreamForReactTag(String streamReactTag) {
         MediaStream stream = localStreams.get(streamReactTag);
 
         if (stream == null) {


### PR DESCRIPTION
When working on [VideoProvider](https://developer.android.com/reference/android/telecom/Connection.VideoProvider) in a new feature of [react-native-callkeep](https://github.com/react-native-webrtc/react-native-callkeep), we need to retrieve the stream of the remote video to display it in the native ongoing video call on Android.

To do so, we have to put the `getStreamForReactTag` as public to be able to retrieve the stream from `react-native-callkeep`.

I haven't found a way to do it without any change on this library, so I made this PR.