### PR TITLE
Update downloadBitcode.sh

### DIFF
--- a/tools/downloadBitcode.sh
+++ b/tools/downloadBitcode.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
-PACKAGE_VERSION=$(cat ${THIS_DIR}/../package.json \
+PACKAGE_VERSION=$(cat "${THIS_DIR}/../package.json" \
   | grep "\"version\":" \
   | head -1 \
   | awk -F: '{ print $2 }' \
@@ -12,7 +12,7 @@ PACKAGE_VERSION=$(cat ${THIS_DIR}/../package.json \
 WEBRTC_DL="https://github.com/react-native-webrtc/react-native-webrtc/releases/download/${PACKAGE_VERSION}/WebRTC.tar.xz"
 
 
-pushd ${THIS_DIR}/../apple
+pushd "${THIS_DIR}/../apple"
 
 # Cleanup
 rm -rf WebRTC.xcframework WebRTC.dSYMs


### PR DESCRIPTION
PACKAGE_VERSION failed to be populated if $THIS_DIR contains whitespace. Wrap them in double-quotes