### PR TITLE
core: update JS local/remote descriptions to match internal state

### DIFF
--- a/RTCSessionDescription.js
+++ b/RTCSessionDescription.js
@@ -5,10 +5,19 @@ export default class RTCSessionDescription {
   type: string;
 
   constructor(info = {type: null, sdp: ''}) {
-    this.sdp = info.sdp;
-    this.type = info.type;
+    this._sdp = info.sdp;
+    this._type = info.type;
   }
+
+  get sdp() {
+    return this._sdp;
+  }
+
+  get type() {
+    return this._type;
+  }
+
   toJSON() {
-    return {sdp: this.sdp, type: this.type};
+    return {sdp: this._sdp, type: this._type};
   }
 }


### PR DESCRIPTION
Specifically here is how we are updating them now:

- localDescription:
    - after calling setLocalDescription
    - with any gathered ICE candidate
    - when ICE gathering state transitions to completed

- remoteDescription:
    - after calling setRemoteDescription
    - when calling addICECandidate

Closes:
https://github.com/react-native-webrtc/react-native-webrtc/pull/787