### PR TITLE
Handle Android IllegalStateException in track.kind()

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -533,7 +533,13 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        String kind = track.kind();
+        String kind = null;
+        try{
+            kind =  track.kind();
+        }catch (IllegalStateException ex){
+            Log.e(TAG, "mediaStreamAddTrack() error", ex);
+        }
+
         if ("audio".equals(kind)) {
             stream.addTrack((AudioTrack)track);
         } else if ("video".equals(kind)) {
@@ -556,7 +562,13 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        String kind = track.kind();
+        String kind = null;
+        try{
+            kind =  track.kind();
+        }catch (IllegalStateException ex){
+            Log.e(TAG, "mediaStreamRemoveTrack() error", ex);
+        }
+
         if ("audio".equals(kind)) {
             stream.removeTrack((AudioTrack)track);
         } else if ("video".equals(kind)) {


### PR DESCRIPTION
I have been getting this error while testing. It has been difficult to handle in the client app because `mediaStreamAddTrack` and `mediaStreamRemoveTrack` are executed on the `ExecutorService` thread. So, I think we should handle it here.