### PR TITLE
getDisplayMedia api improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Rendering RTCView.
 By calling this method the JavaScript global namespace gets "polluted" with the following additions:
 
 * `navigator.mediaDevices.getUserMedia()`
+* `navigator.mediaDevices.getDisplayMedia()`
 * `navigator.mediaDevices.enumerateDevices()`
 * `window.RTCPeerConnection`
 * `window.RTCIceCandidate`

--- a/getDisplayMedia.js
+++ b/getDisplayMedia.js
@@ -7,11 +7,7 @@ import MediaStreamError from './MediaStreamError';
 
 const { WebRTCModule } = NativeModules;
 
-export default function getDisplayMedia(constraints) {
-    if (!constraints || !constraints.video) {
-        return Promise.reject(new TypeError());
-    }
-
+export default function getDisplayMedia() {
     return new Promise((resolve, reject) => {
         WebRTCModule.getDisplayMedia()
             .then(data => {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ function registerGlobals() {
 	navigator.mediaDevices.getUserMedia =
 		mediaDevices.getUserMedia.bind(mediaDevices);
 
+	navigator.mediaDevices.getDisplayMedia =
+		mediaDevices.getDisplayMedia.bind(mediaDevices);
+
 	navigator.mediaDevices.enumerateDevices =
 		mediaDevices.enumerateDevices.bind(mediaDevices);
 


### PR DESCRIPTION
This PR removes the restriction that getDisplayMedia has to send a constraints object, in the web api it is completely optional, and in this codebase it is not used anywhere. I believe removing it will make it easier not to trip over these implementation details.

Likewise, getDisplayMedia is also added in registerGlobals under navigator.mediaDevices.getDisplayMedia, as it is in the web api. No reason to register getUserMedia but not getDisplayMedia.

Readme is also updated to state that getDisplayMedia gets exposed when registerGlobals is called.