### PR TITLE
android: fix chrash on removeSink

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -335,7 +335,15 @@ public class WebRTCView extends ViewGroup {
     private void removeRendererFromVideoTrack() {
         if (rendererAttached) {
             if (videoTrack != null) {
-                videoTrack.removeSink(surfaceViewRenderer);
+                // XXX If WebRTCModule#mediaStreamTrackRelease has already been
+                // invoked on videoTrack, then it is no longer safe to call removeSink
+                // on the instance, it will throw IllegalStateException.
+                try {
+                    videoTrack.removeSink(surfaceViewRenderer);
+                } catch (Throwable tr) {
+                    // Releasing streams happens in the WebRTC thread, thus we might (briefly) hold
+                    // a reference to a released stream. Just ignore the error and move on.
+                }
             }
 
             surfaceViewRenderer.release();
@@ -538,7 +546,7 @@ public class WebRTCView extends ViewGroup {
 
             // XXX If WebRTCModule#mediaStreamTrackRelease has already been
             // invoked on videoTrack, then it is no longer safe to call addSink
-            // the instance, it will throw IllegalStateException.
+            // on the instance, it will throw IllegalStateException.
             try {
                 videoTrack.addSink(surfaceViewRenderer);
             } catch (Throwable tr) {


### PR DESCRIPTION
Paetially reverts:
https://github.com/react-native-webrtc/react-native-webrtc/commit/cec18d23448fc3a96605838d11b8030074643e06

I was wrong about removeSink, it may throw because we are running
operations on different threads and are neck-deep in thread-safety
territory. If videoTrack.dispose() is running while we try to call
removeSink(), it will crash.

Fixes:
https://github.com/react-native-webrtc/react-native-webrtc/issues/1077