### PR TITLE
ios: De-registering from kvo on device when dealloc-ing VideoCaptureController

### DIFF
--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -56,6 +56,10 @@
     return self;
 }
 
+- (void)dealloc {
+    self.device = NULL;
+}
+
 - (void)startCapture {
     if (self.deviceId) {
         self.device = [AVCaptureDevice deviceWithUniqueID:self.deviceId];


### PR DESCRIPTION
`VideoCaptureController` must de-register from observing key-value changes on its device at dealloc time, in case capturing was not already stopped before, otherwise it can happen for k-v changes on that reused device object to cause invocations on the deallocated capture controller and crash the app.