### PR TITLE
fix "Failed to create EGL context" exception

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -107,9 +107,11 @@ class GetUserMediaImpl {
 
         AudioSource audioSource = pcFactory.createAudioSource(peerConstraints);
         AudioTrack track = pcFactory.createAudioTrack(id, audioSource);
+        
+        // surfaceTextureHelper is initialized for videoTrack only, so its null here.
         tracks.put(
             id,
-            new TrackPrivate(track, audioSource, /* videoCapturer */ null, null));
+            new TrackPrivate(track, audioSource, /* videoCapturer */ null, /* surfaceTextureHelper */ null));
 
         return track;
     }


### PR DESCRIPTION
Problem: react-native-webrtc library crashes with "Failed to create EGL context" exception even with single context because EGL context is not released properly on dispose. 

Investigation: I explored chromium library and found this in there documented code at VideoCapturer.java
/*The caller still has ownership of {@code
* surfaceTextureHelper} and is responsible for making sure surfaceTextureHelper.dispose() is
* called. This also means that the caller can reuse the SurfaceTextureHelper to initialize a new
* VideoCapturer once the previous VideoCapturer has been disposed. */

It is further documented in SurfaceTextureHelper.java:
/**
* Helper class for using a SurfaceTexture to create WebRTC VideoFrames. In order to create WebRTC
* VideoFrames, render onto the SurfaceTexture. The frames will be delivered to the listener. Only
* one texture frame can be in flight at once, so the frame must be released in order to receive a
* new frame. Call stopListening() to stop receiveing new frames. Call dispose to release all
* resources once the texture frame is released.
*/

So, this Pull request aims to dispose surfaceTextureHelper properly when track are disposed.
Another reference to the problem can be found here: https://stackoverflow.com/questions/45392309/failed-to-create-egl-context