### PR TITLE
android: update uuid to get rid of the warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
       "dependencies": {
         "base64-js": "1.5.1",
         "event-target-shim": "6.0.2",
-        "tar": "6.1.11",
-        "uuid": "8.3.2"
+        "tar": "6.1.11"
       },
       "devDependencies": {
         "husky": "7.0.2",
@@ -1146,14 +1145,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2040,11 +2031,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "base64-js": "1.5.1",
         "event-target-shim": "6.0.2",
         "tar": "6.1.11",
-        "uuid": "3.4.0"
+        "uuid": "8.3.2"
       },
       "devDependencies": {
         "husky": "7.0.2",
@@ -1147,12 +1147,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -2043,9 +2042,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "base64-js": "1.5.1",
     "event-target-shim": "6.0.2",
     "tar": "6.1.11",
-    "uuid": "3.4.0"
+    "uuid": "8.3.2"
   },
   "peerDependencies": {
     "react-native": ">=0.60.0"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "dependencies": {
     "base64-js": "1.5.1",
     "event-target-shim": "6.0.2",
-    "tar": "6.1.11",
-    "uuid": "8.3.2"
+    "tar": "6.1.11"
   },
   "peerDependencies": {
     "react-native": ">=0.60.0"

--- a/src/MediaStream.js
+++ b/src/MediaStream.js
@@ -1,7 +1,7 @@
 
 import { NativeModules } from 'react-native';
 import { defineCustomEventTarget } from 'event-target-shim';
-import { v4 as uuidv4 } from 'uuid';
+import { uniqueID } from './RTCUtil';
 
 import MediaStreamTrack from './MediaStreamTrack';
 
@@ -40,7 +40,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         super();
 
         // Assigm a UUID to start with. It may get overridden for remote streams.
-        this.id = uuidv4();
+        this.id = uniqueID();
         // Local MediaStreams are created by WebRTCModule to have their id and
         // reactTag equal because WebRTCModule follows the respective standard's
         // recommendation for id generation i.e. uses UUID which is unique enough

--- a/src/MediaStream.js
+++ b/src/MediaStream.js
@@ -1,7 +1,7 @@
 
 import { NativeModules } from 'react-native';
 import { defineCustomEventTarget } from 'event-target-shim';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 import MediaStreamTrack from './MediaStreamTrack';
 
@@ -40,7 +40,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         super();
 
         // Assigm a UUID to start with. It may get overridden for remote streams.
-        this.id = uuid.v4();
+        this.id = uuidv4();
         // Local MediaStreams are created by WebRTCModule to have their id and
         // reactTag equal because WebRTCModule follows the respective standard's
         // recommendation for id generation i.e. uses UUID which is unique enough

--- a/src/RTCUtil.js
+++ b/src/RTCUtil.js
@@ -112,6 +112,14 @@ function normalizeMediaConstraints(constraints, mediaType) {
     }
 }
 
+function chr4() {
+    return Math.random().toString(16).slice(-4);
+}
+
+export function uniqueID() {
+    return `${chr4()}${chr4()}-${chr4()}-${chr4()}-${chr4()}-${chr4()}${chr4()}${chr4()}`;
+}
+
 /**
  * Utility for deep cloning an object. Object.assign() only does a shallow copy.
  *

--- a/src/RTCUtil.js
+++ b/src/RTCUtil.js
@@ -113,8 +113,8 @@ function normalizeMediaConstraints(constraints, mediaType) {
 }
 
 /**
- * Utility for creating random float point values.
- * We then chop off 4 from the end after converting to a string.
+ * Utility for creating short random strings from float point values.
+ * We take 4 characters from the end after converting to a string.
  * Conversion to string gives us some letters as we don't want just numbers.
  * Should be suitable to pass for enough randomness.
  *

--- a/src/RTCUtil.js
+++ b/src/RTCUtil.js
@@ -112,10 +112,23 @@ function normalizeMediaConstraints(constraints, mediaType) {
     }
 }
 
+/**
+ * Utility for creating random float point values.
+ * We then chop off 4 from the end after converting to a string.
+ * Conversion to string gives us some letters as we don't want just numbers.
+ * Should be suitable to pass for enough randomness.
+ *
+ * @return {String} 4 random characters
+ */
 function chr4() {
     return Math.random().toString(16).slice(-4);
 }
 
+/**
+ * Put together a random string in UUIDv4 format {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+ *
+ * @return {String} uuidv4
+ */
 export function uniqueID() {
     return `${chr4()}${chr4()}-${chr4()}-${chr4()}-${chr4()}-${chr4()}${chr4()}${chr4()}`;
 }


### PR DESCRIPTION
Started getting this warning recently.

warning react-native-webrtc > uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

Should be a simple non-disruptive upgrade.