### PR TITLE
android,ios: update WebRTC to M98

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -98,6 +98,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
         PeerConnectionFactory.initialize(
             PeerConnectionFactory.InitializationOptions.builder(reactContext)
+                .setFieldTrials("WebRTC-DataChannel-Dcsctp/Enabled/")
                 .setNativeLibraryLoader(new LibraryLoader())
                 .setInjectableLogger(injectableLogger, loggingSeverity)
                 .createInitializationOptions());

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -15,6 +15,7 @@
 
 #import <WebRTC/RTCDefaultVideoDecoderFactory.h>
 #import <WebRTC/RTCDefaultVideoEncoderFactory.h>
+#import <WebRTC/RTCFieldTrials.h>
 
 #import "WebRTCModule.h"
 #import "WebRTCModule+RTCPeerConnection.h"
@@ -56,6 +57,9 @@
 {
   self = [super init];
   if (self) {
+    NSDictionary *fieldTrials = @{@"WebRTC-DataChannel-Dcsctp": @"Enabled"};
+    RTCInitFieldTrialDictionary(fieldTrials);
+
     if (encoderFactory == nil) {
       encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-webrtc",
-  "version": "1.94.2",
+  "version": "1.98.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-webrtc",
-      "version": "1.94.2",
+      "version": "1.98.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "1.94.2",
+  "version": "1.98.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"
@@ -41,8 +41,8 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "webrtc-builds": {
-    "android": "https://github.com/jitsi/webrtc/releases/download/v94.0.0/android-webrtc.tgz",
-    "ios": "https://github.com/jitsi/webrtc/releases/download/v94.0.0/WebRTC.xcframework.tgz",
-    "ios-bitcode": "https://github.com/jitsi/webrtc/releases/download/v94.0.0/WebRTC.xcframework-bitcode.tgz"
+    "android": "https://github.com/jitsi/webrtc/releases/download/v98.0.0/android-webrtc.tgz",
+    "ios": "https://github.com/jitsi/webrtc/releases/download/v98.0.0/WebRTC.xcframework.tgz",
+    "ios-bitcode": "https://github.com/jitsi/webrtc/releases/download/v98.0.0/WebRTC.xcframework-bitcode.tgz"
   }
 }

--- a/tools/build-webrtc.py
+++ b/tools/build-webrtc.py
@@ -37,12 +37,17 @@ def build_gn_args(platform_args):
 GN_COMMON_ARGS = [
     'is_component_build=false',
     'rtc_libvpx_build_vp9=true',
+    'rtc_build_dcsctp=true',
+    'rtc_build_usrsctp=false',
+    'rtc_enable_protobuf=false',
+    'rtc_include_tests=false',
     'is_debug=%s',
     'target_cpu="%s"'
 ]
 
 _GN_APPLE_COMMON = [
-    'enable_dsyms=true',
+    'enable_dsyms=false',
+    'rtc_enable_symbol_export=false',
     'rtc_enable_objc_symbol_export=true',
     'rtc_include_tests=false'
 ]
@@ -51,15 +56,14 @@ _GN_IOS_ARGS = [
     'enable_ios_bitcode=true',
     'ios_deployment_target="12.0"',
     'ios_enable_code_signing=false',
+    'use_lld=false',
     'target_os="ios"',
-    'use_xcode_clang=true',
     'target_environment="%s"'
 ]
 GN_IOS_ARGS = build_gn_args(_GN_APPLE_COMMON + _GN_IOS_ARGS)
 
 _GN_MACOS_ARGS = [
-    'target_os="mac"',
-    'use_xcode_clang=false'
+    'target_os="mac"'
 ]
 GN_MACOS_ARGS = build_gn_args(_GN_APPLE_COMMON + _GN_MACOS_ARGS)
 


### PR DESCRIPTION
NOTE: this build uses dsSCTP instead of usrsctp for data channels, any feedback while testing them is welcome.