### PR TITLE
android,ios: refactor remote mute detection

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -349,7 +349,7 @@ class PeerConnectionObserver implements PeerConnection.Observer {
             trackInfo.putBoolean("remote", true);
             tracks.pushMap(trackInfo);
 
-            videoTrackAdapters.addAdapter(streamReactTag, track);
+            videoTrackAdapters.addAdapter(track);
         }
         for (int i = 0; i < mediaStream.audioTracks.size(); i++) {
             AudioTrack track = mediaStream.audioTracks.get(i);

--- a/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
+++ b/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
@@ -35,31 +35,31 @@ public class VideoTrackAdapter {
         this.webRTCModule = webRTCModule;
     }
 
-    public void addAdapter(String streamReactTag, VideoTrack videoTrack) {
+    public void addAdapter(VideoTrack videoTrack) {
         String trackId = videoTrack.id();
-        if (!muteImplMap.containsKey(trackId)) {
-            TrackMuteUnmuteImpl onMuteImpl
-                = new TrackMuteUnmuteImpl(streamReactTag, trackId);
-            Log.d(TAG, "Created adapter for " + trackId);
-            muteImplMap.put(trackId, onMuteImpl);
-            videoTrack.addSink(onMuteImpl);
-            onMuteImpl.start();
-        } else {
-            Log.w(
-                TAG, "Attempted to add adapter twice for track ID: " + trackId);
+        if (muteImplMap.containsKey(trackId)) {
+            Log.w(TAG, "Attempted to add adapter twice for track ID: " + trackId);
+            return;
         }
+
+        TrackMuteUnmuteImpl onMuteImpl = new TrackMuteUnmuteImpl(trackId);
+        Log.d(TAG, "Created adapter for " + trackId);
+        muteImplMap.put(trackId, onMuteImpl);
+        videoTrack.addSink(onMuteImpl);
+        onMuteImpl.start();
     }
 
     public void removeAdapter(VideoTrack videoTrack) {
         String trackId = videoTrack.id();
         TrackMuteUnmuteImpl onMuteImpl = muteImplMap.remove(trackId);
-        if (onMuteImpl != null) {
-            videoTrack.removeSink(onMuteImpl);
-            onMuteImpl.dispose();
-            Log.d(TAG, "Deleted adapter for " + trackId);
-        } else {
+        if (onMuteImpl == null) {
             Log.w(TAG, "removeAdapter - no adapter for " + trackId);
+            return;
         }
+
+        videoTrack.removeSink(onMuteImpl);
+        onMuteImpl.dispose();
+        Log.d(TAG, "Deleted adapter for " + trackId);
     }
 
     /**
@@ -71,11 +71,9 @@ public class VideoTrackAdapter {
         private volatile boolean disposed;
         private AtomicInteger frameCounter;
         private boolean mutedState;
-        private final String streamReactTag;
         private final String trackId;
 
-        TrackMuteUnmuteImpl(String streamReactTag, String trackId) {
-            this.streamReactTag = streamReactTag;
+        TrackMuteUnmuteImpl(String trackId) {
             this.trackId = trackId;
             this.frameCounter = new AtomicInteger();
         }
@@ -118,14 +116,12 @@ public class VideoTrackAdapter {
         private void emitMuteEvent(boolean muted) {
             WritableMap params = Arguments.createMap();
             params.putInt("peerConnectionId", peerConnectionId);
-            params.putString("streamReactTag", streamReactTag);
             params.putString("trackId", trackId);
             params.putBoolean("muted", muted);
 
             Log.d(TAG,
                 (muted ? "Mute" : "Unmute" )
                     + " event pcId: " + peerConnectionId
-                    + " streamTag: " + streamReactTag
                     + " trackId: " + trackId);
 
             VideoTrackAdapter.this.webRTCModule.sendEvent(

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -513,7 +513,7 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
   NSMutableArray *tracks = [NSMutableArray array];
   for (RTCVideoTrack *track in stream.videoTracks) {
     peerConnection.remoteTracks[track.trackId] = track;
-    [peerConnection addVideoTrackAdapter:streamReactTag track:track];
+    [peerConnection addVideoTrackAdapter:track];
     [tracks addObject:@{@"id": track.trackId, @"kind": track.kind, @"label": track.trackId, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
   }
   for (RTCAudioTrack *track in stream.audioTracks) {

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.h
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.h
@@ -6,7 +6,7 @@
 
 @property (nonatomic, strong) NSMutableDictionary<NSString *,  id> *videoTrackAdapters;
 
-- (void)addVideoTrackAdapter:(NSString*)streamReactId track:(RTCVideoTrack*)track;
+- (void)addVideoTrackAdapter:(RTCVideoTrack*)track;
 - (void)removeVideoTrackAdapter:(RTCVideoTrack*)track;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
@@ -23,13 +23,12 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
 
 /* Entity responsible for detecting track mute / unmute events. It's implemented
  * as a video renderer, which counts the number of frames, and if it sees them
- * stalled for the default interval it will emit a mute event. If frame keep
+ * stalled for the default interval it will emit a mute event. If frames keep
  * being received, the track unmute event will be emitted.
  */
 @interface TrackMuteDetector : NSObject<RTCVideoRenderer>
 
 @property (copy, nonatomic) NSNumber *peerConnectionId;
-@property (copy, nonatomic) NSString *streamReactTag;
 @property (copy, nonatomic) NSString *trackId;
 @property (weak, nonatomic) WebRTCModule *module;
 
@@ -43,13 +42,11 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
 }
 
 - (instancetype)initWith:(NSNumber*)peerConnectionId
-          streamReactTag:(NSString*)streamReactTag
                  trackId:(NSString*)trackId
             webRTCModule:(WebRTCModule*)module {
     self = [super init];
     if (self) {
         self.peerConnectionId = peerConnectionId;
-        self.streamReactTag = streamReactTag;
         self.trackId = trackId;
         self.module = module;
 
@@ -74,14 +71,12 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
     [self.module sendEventWithName:kEventMediaStreamTrackMuteChanged
                               body:@{
                                 @"peerConnectionId": self.peerConnectionId,
-                                @"streamReactTag": self.streamReactTag,
                                 @"trackId": self.trackId,
                                 @"muted": @(muted)
                               }];
-    RCTLog(@"[VideoTrackAdapter] %@ event for %@ %@ %@",
+    RCTLog(@"[VideoTrackAdapter] %@ event for pc %@ track %@",
           muted ? @"Mute" : @"Unmute",
           self.peerConnectionId,
-          self.streamReactTag,
           self.trackId);
 }
 
@@ -144,7 +139,7 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
     objc_setAssociatedObject(self, @selector(videoTrackAdapters), videoTrackAdapters, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)addVideoTrackAdapter:(NSString*)streamReactId track:(RTCVideoTrack*)track {
+- (void)addVideoTrackAdapter:(RTCVideoTrack*)track {
     NSString* trackId = track.trackId;
     if ([self.videoTrackAdapters objectForKey:trackId] != nil) {
         RCTLogWarn(@"[VideoTrackAdapter] Adapter already exists for track %@", trackId);
@@ -153,7 +148,6 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
 
     TrackMuteDetector* muteDetector
         = [[TrackMuteDetector alloc] initWith:self.reactTag
-                                streamReactTag:streamReactId
                                       trackId:trackId
                                  webRTCModule:self.webRTCModule];
     [self.videoTrackAdapters setObject:muteDetector forKey:trackId];

--- a/src/MediaStreamTrack.js
+++ b/src/MediaStreamTrack.js
@@ -14,11 +14,11 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
     _constraints: Object;
     _enabled: boolean;
     _settings: Object;
+    _muted: boolean;
 
     id: string;
     kind: string;
     label: string;
-    muted: boolean;
     // readyState in java: INITIALIZING, LIVE, ENDED, FAILED
     readyState: MediaStreamTrackState;
     remote: boolean;
@@ -29,11 +29,11 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         this._constraints = info.constraints || {};
         this._enabled = info.enabled;
         this._settings = info.settings || {};
+        this._muted = false;
 
         this.id = info.id;
         this.kind = info.kind;
         this.label = info.label;
-        this.muted = false;
         this.remote = info.remote;
 
         const _readyState = info.readyState.toLowerCase();
@@ -50,7 +50,10 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         }
         WebRTCModule.mediaStreamTrackSetEnabled(this.id, !this._enabled);
         this._enabled = !this._enabled;
-        this.muted = !this._enabled;
+    }
+
+    get muted(): boolean {
+        return this._muted;
     }
 
     stop() {

--- a/src/RTCPeerConnection.js
+++ b/src/RTCPeerConnection.js
@@ -205,12 +205,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         WebRTCModule.peerConnectionRestartIce(this._peerConnectionId);
     }
 
-    _getTrack(streamReactTag, trackId): MediaStreamTrack {
-        const stream = this._remoteStreams.find(stream => stream._reactTag === streamReactTag);
-
-        return stream && stream._tracks.find(track => track.id === trackId);
-    }
-
     _unregisterEvents(): void {
         this._subscriptions.forEach(e => e.remove());
         this._subscriptions = [];
@@ -280,9 +274,16 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                 if (ev.peerConnectionId !== this._peerConnectionId) {
                     return;
                 }
-                const track = this._getTrack(ev.streamReactTag, ev.trackId);
+                let track;
+                for (const stream of this._remoteStreams) {
+                    const t = stream._tracks.find(track => track.id === ev.trackId);
+                    if (t) {
+                        track = t;
+                        break;
+                    }
+                }
                 if (track) {
-                    track.muted = ev.muted;
+                    track._muted = ev.muted;
                     const eventName = ev.muted ? 'mute' : 'unmute';
                     track.dispatchEvent(new MediaStreamTrackEvent(eventName, { track }));
                 }


### PR DESCRIPTION
Don't use the stream ID as an identifier, just the track ID will do
since we have the PC ID already and this is only applied to remote
tracks.

In addition make the `muted` property readonly (as per the spec) and
also don't set it when `enabled` is set.