### PR TITLE
ios: fix generated JSON for numeric stats values

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -444,6 +444,8 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
             NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
             [s appendString:jsonString];
         }
+    } else if ([statisticsValue isKindOfClass:[NSNumber class]]) {
+        [s appendString:[NSString stringWithFormat:@"%@", statisticsValue]];
     } else {
         [s appendString:@"\""];
         [s appendString:[NSString stringWithFormat:@"%@", statisticsValue]];


### PR DESCRIPTION
Until now numeric values had been treated the same as strings so they were serialized with double quotes around them, leading to the wrong data type (string instead of number) on the JS side. This adds the correct handling for numeric values.

Examples from the `pc.getStats()` results (see e.g. the `packetsSent` and `bytesSent` values):
**before fix**
```
"RTCOutboundRTPAudioStream_627959139": {
  "timestamp": 1651482998659.26,
  "type": "outbound-rtp",
  "id": "RTCOutboundRTPAudioStream_627959139",
  "codecId": "RTCCodec_audio_Outbound_111",
  "mediaType": "audio",
  "trackId": "RTCMediaStreamTrack_sender_1",
  "remoteId": "RTCRemoteInboundRtpAudioStream_627959139",
  "packetsSent": "1439",
  "transportId": "RTCTransport_audio_1",
  "retransmittedPacketsSent": "0",
  "headerBytesSent": "28780",
  "ssrc": "627959139",
  "mediaSourceId": "RTCAudioSource_1",
  "kind": "audio",
  "nackCount": "0",
  "retransmittedBytesSent": "0",
  "bytesSent": "231822"
}
```

**with fix**
```
"RTCOutboundRTPAudioStream_2804105957": {
  "timestamp": 1651483191099.516,
  "type": "outbound-rtp",
  "id": "RTCOutboundRTPAudioStream_2804105957",
  "codecId": "RTCCodec_audio_Outbound_111",
  "mediaType": "audio",
  "trackId": "RTCMediaStreamTrack_sender_1",
  "remoteId": "RTCRemoteInboundRtpAudioStream_2804105957",
  "packetsSent": 1437,
  "transportId": "RTCTransport_audio_1",
  "retransmittedPacketsSent": 0,
  "headerBytesSent": 28740,
  "ssrc": 2804105957,
  "mediaSourceId": "RTCAudioSource_1",
  "kind": "audio",
  "nackCount": 0,
  "retransmittedBytesSent": 0,
  "bytesSent": 231357
}
```
