### PR TITLE
Cleanup Type Issues

### DIFF
--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -106,7 +106,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         return this._tracks.filter(track => track.kind === 'video');
     }
 
-    clone() {
+    clone(): never {
         throw new Error('Not implemented.');
     }
 

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -11,7 +11,7 @@ const MEDIA_STREAM_EVENTS = ['active', 'inactive', 'addtrack', 'removetrack'];
 
 export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM_EVENTS) {
     id: string;
-    active: boolean = true;
+    active = true;
 
     _tracks: MediaStreamTrack[] = [];
 

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -72,7 +72,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         }
     }
 
-    addTrack(track: MediaStreamTrack) {
+    addTrack(track: MediaStreamTrack): void {
         const index = this._tracks.indexOf(track);
         if (index !== -1) {
             return;
@@ -81,7 +81,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         WebRTCModule.mediaStreamAddTrack(this._reactTag, track.id);
     }
 
-    removeTrack(track: MediaStreamTrack) {
+    removeTrack(track: MediaStreamTrack): void {
         const index = this._tracks.indexOf(track);
         if (index === -1) {
             return;
@@ -110,11 +110,11 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         throw new Error('Not implemented.');
     }
 
-    toURL() {
+    toURL(): string {
         return this._reactTag;
     }
 
-    release(releaseTracks = true) {
+    release(releaseTracks = true): void {
         const tracks = [...this._tracks];
         for (const track of tracks) {
             this.removeTrack(track);

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -13,7 +13,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
     id: string;
     active: boolean = true;
 
-    _tracks: Array<MediaStreamTrack> = [];
+    _tracks: MediaStreamTrack[] = [];
 
     /**
      * The identifier of this MediaStream unique within the associated
@@ -90,7 +90,7 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         WebRTCModule.mediaStreamRemoveTrack(this._reactTag, track.id);
     }
 
-    getTracks(): Array<MediaStreamTrack> {
+    getTracks(): MediaStreamTrack[] {
         return this._tracks.slice();
     }
 
@@ -98,11 +98,11 @@ export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM
         return this._tracks.find(track => track.id === trackId);
     }
 
-    getAudioTracks(): Array<MediaStreamTrack> {
+    getAudioTracks(): MediaStreamTrack[] {
         return this._tracks.filter(track => track.kind === 'audio');
     }
 
-    getVideoTracks(): Array<MediaStreamTrack> {
+    getVideoTracks(): MediaStreamTrack[] {
         return this._tracks.filter(track => track.kind === 'video');
     }
 

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -55,7 +55,7 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         return this._muted;
     }
 
-    stop() {
+    stop(): void {
         WebRTCModule.mediaStreamTrackSetEnabled(this.id, false);
         this.readyState = 'ended';
         // TODO: save some stopped flag?
@@ -68,7 +68,7 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
      * This is how the reference application (AppRTCMobile) implements camera
      * switching.
      */
-    _switchCamera() {
+    _switchCamera(): void {
         if (this.remote) {
             throw new Error('Not implemented for remote tracks');
         }
@@ -98,7 +98,7 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         return deepClone(this._settings);
     }
 
-    release() {
+    release(): void {
         WebRTCModule.mediaStreamTrackRelease(this.id);
     }
 }

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -78,15 +78,15 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
     }
 
-    applyConstraints() {
+    applyConstraints(): never {
         throw new Error('Not implemented.');
     }
 
-    clone() {
+    clone(): never {
         throw new Error('Not implemented.');
     }
 
-    getCapabilities() {
+    getCapabilities(): never {
         throw new Error('Not implemented.');
     }
 

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -79,7 +79,7 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
         return this._readyState;
     }
 
-    send(data: string | ArrayBuffer | ArrayBufferView) {
+    send(data: string | ArrayBuffer | ArrayBufferView): void {
         if (typeof data === 'string') {
             WebRTCModule.dataChannelSend(this._peerConnectionId, this._reactTag, data, 'text');
             return;
@@ -96,19 +96,19 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
         WebRTCModule.dataChannelSend(this._peerConnectionId, this._reactTag, base64.fromByteArray(data as Uint8Array), 'binary');
     }
 
-    close() {
+    close(): void {
         if (this._readyState === 'closing' || this._readyState === 'closed') {
             return;
         }
         WebRTCModule.dataChannelClose(this._peerConnectionId, this._reactTag);
     }
 
-    _unregisterEvents() {
+    _unregisterEvents(): void {
         this._subscriptions.forEach(e => e.remove());
         this._subscriptions = [];
     }
 
-    _registerEvents() {
+    _registerEvents(): void {
         this._subscriptions = [
             EventEmitter.addListener('dataChannelStateChanged', ev => {
                 if (ev.reactTag !== this._reactTag) {

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -79,6 +79,9 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
         return this._readyState;
     }
 
+    send(data: string): void;
+    send(data: ArrayBuffer): void;
+    send(data: ArrayBufferView): void;
     send(data: string | ArrayBuffer | ArrayBufferView): void {
         if (typeof data === 'string') {
             WebRTCModule.dataChannelSend(this._peerConnectionId, this._reactTag, data, 'text');

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -25,9 +25,9 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
     _readyState: RTCDataChannelState;
     _subscriptions: any[] = [];
 
-    binaryType: string = 'arraybuffer'; // we only support 'arraybuffer'
-    bufferedAmount: number = 0;
-    bufferedAmountLowThreshold: number = 0;
+    binaryType = 'arraybuffer'; // we only support 'arraybuffer'
+    bufferedAmount = 0;
+    bufferedAmountLowThreshold = 0;
 
     constructor(info) {
         super();

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -23,7 +23,7 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
     _ordered: boolean;
     _protocol: string;
     _readyState: RTCDataChannelState;
-    _subscriptions: Array<any> = [];
+    _subscriptions: any[] = [];
 
     binaryType: string = 'arraybuffer'; // we only support 'arraybuffer'
     bufferedAmount: number = 0;

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -75,7 +75,7 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         this._registerEvents();
     }
 
-    addStream(stream: MediaStream) {
+    addStream(stream: MediaStream): void {
         const index = this._localStreams.indexOf(stream);
         if (index !== -1) {
             return;
@@ -84,7 +84,7 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         this._localStreams.push(stream);
     }
 
-    removeStream(stream: MediaStream) {
+    removeStream(stream: MediaStream): void {
         const index = this._localStreams.indexOf(stream);
         if (index === -1) {
             return;
@@ -125,7 +125,7 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         });
     }
 
-    setConfiguration(configuration) {
+    setConfiguration(configuration): void {
         WebRTCModule.peerConnectionSetConfiguration(configuration, this._peerConnectionId);
     }
 
@@ -188,19 +188,19 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         });
     }
 
-    getLocalStreams() {
+    getLocalStreams(): MediaStream[] {
         return this._localStreams.slice();
     }
 
-    getRemoteStreams() {
+    getRemoteStreams(): MediaStream[] {
         return this._remoteStreams.slice();
     }
 
-    close() {
+    close(): void {
         WebRTCModule.peerConnectionClose(this._peerConnectionId);
     }
 
-    restartIce() {
+    restartIce(): void {
         WebRTCModule.peerConnectionRestartIce(this._peerConnectionId);
     }
 
@@ -339,7 +339,7 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
      * values with which to initialize corresponding attributes of the new
      * instance such as id
      */
-    createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit) {
+    createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel {
         if (dataChannelDict && 'id' in dataChannelDict) {
             const id = dataChannelDict.id;
             if (typeof id !== 'number') {

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -64,9 +64,9 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
     iceConnectionState: RTCIceConnectionState = 'new';
 
     _peerConnectionId: number;
-    _localStreams: Array<MediaStream> = [];
-    _remoteStreams: Array<MediaStream> = [];
-    _subscriptions: Array<any> = [];
+    _localStreams: MediaStream[] = [];
+    _remoteStreams: MediaStream[] = [];
+    _subscriptions: any[] = [];
 
     constructor(configuration) {
         super();

--- a/src/RTCSessionDescription.ts
+++ b/src/RTCSessionDescription.ts
@@ -8,15 +8,15 @@ export default class RTCSessionDescription {
         this._type = info.type;
     }
 
-    get sdp() {
+    get sdp(): string {
         return this._sdp;
     }
 
-    get type() {
+    get type(): string | null {
         return this._type;
     }
 
-    toJSON() {
+    toJSON(): { sdp: string, type: string | null } {
         return {
             sdp: this._sdp,
             type: this._type

--- a/src/RTCUtil.ts
+++ b/src/RTCUtil.ts
@@ -139,7 +139,7 @@ export function uniqueID() {
  * @param {Object} obj - object to be cloned
  * @return {Object} cloned obj
  */
-export function deepClone(obj) {
+export function deepClone<T>(obj: T): T {
     return JSON.parse(JSON.stringify(obj));
 }
 

--- a/src/RTCUtil.ts
+++ b/src/RTCUtil.ts
@@ -129,7 +129,7 @@ function chr4() {
  *
  * @return {String} uuidv4
  */
-export function uniqueID() {
+export function uniqueID(): string {
     return `${chr4()}${chr4()}-${chr4()}-${chr4()}-${chr4()}-${chr4()}${chr4()}${chr4()}`;
 }
 

--- a/src/getDisplayMedia.ts
+++ b/src/getDisplayMedia.ts
@@ -6,7 +6,7 @@ import MediaStreamError from './MediaStreamError';
 
 const { WebRTCModule } = NativeModules;
 
-export default function getDisplayMedia() {
+export default function getDisplayMedia(): Promise<MediaStream> {
     return new Promise((resolve, reject) => {
         WebRTCModule.getDisplayMedia().then(
             data => {

--- a/src/getUserMedia.ts
+++ b/src/getUserMedia.ts
@@ -32,7 +32,7 @@ export default function getUserMedia(constraints: Constraints = {}) {
     constraints = RTCUtil.normalizeConstraints(constraints);
 
     // Request required permissions
-    const reqPermissions: Array<Promise<boolean>> = [];
+    const reqPermissions: Promise<boolean>[] = [];
     if (constraints.audio) {
         reqPermissions.push(permissions.request({ name: 'microphone' }));
     } else {

--- a/src/getUserMedia.ts
+++ b/src/getUserMedia.ts
@@ -13,7 +13,7 @@ interface Constraints {
     video?: boolean | object;
 }
 
-export default function getUserMedia(constraints: Constraints = {}) {
+export default function getUserMedia(constraints: Constraints = {}): Promise<MediaStream> {
     // According to
     // https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia,
     // the constraints argument is a dictionary of type MediaStreamConstraints.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export {
     registerGlobals
 };
 
-function registerGlobals() {
+function registerGlobals(): void {
     // Should not happen. React Native has a global navigator object.
     if (typeof global.navigator !== 'object') {
         throw new Error('navigator is not an object');


### PR DESCRIPTION
The current version of the repo has numerous type issues that make `react-native-webrtc` rather difficult to use in a TypeScript project. I've added explicit return types to numerous functions (as they were resolving to `unknown` or `any` on any external project that used `react-native-webrtc`), as well cleaned up several other minor aspects of the code base.

There are other changes that need to be made, but this pull request primarily focuses on the return types and a few other miscellaneous changes.