### PR TITLE
Unified plan support

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
@@ -19,6 +20,8 @@ import org.webrtc.MediaStream;
 import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnection;
 import org.webrtc.RtpReceiver;
+import org.webrtc.RtpSender;
+import org.webrtc.RtpTransceiver;
 import org.webrtc.SessionDescription;
 import org.webrtc.VideoTrack;
 
@@ -30,6 +33,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 class PeerConnectionObserver implements PeerConnection.Observer {
@@ -37,8 +41,9 @@ class PeerConnectionObserver implements PeerConnection.Observer {
 
     private final Map<String, DataChannelWrapper> dataChannels;
     private final int id;
+    private int transceiverNextId = 0;
+
     private PeerConnection peerConnection;
-    final List<MediaStream> localStreams;
     final Map<String, MediaStream> remoteStreams;
     final Map<String, MediaStreamTrack> remoteTracks;
     private final VideoTrackAdapter videoTrackAdapters;
@@ -48,47 +53,9 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         this.webRTCModule = webRTCModule;
         this.id = id;
         this.dataChannels = new HashMap<>();
-        this.localStreams = new ArrayList<>();
         this.remoteStreams = new HashMap<>();
         this.remoteTracks = new HashMap<>();
         this.videoTrackAdapters = new VideoTrackAdapter(webRTCModule, id);
-    }
-
-    /**
-     * Adds a specific local <tt>MediaStream</tt> to the associated
-     * <tt>PeerConnection</tt>.
-     *
-     * @param localStream the local <tt>MediaStream</tt> to add to the
-     *                    associated <tt>PeerConnection</tt>
-     * @return <tt>true</tt> if the specified <tt>localStream</tt> was added to
-     * the associated <tt>PeerConnection</tt>; otherwise, <tt>false</tt>
-     */
-    boolean addStream(MediaStream localStream) {
-        if (peerConnection != null && peerConnection.addStream(localStream)) {
-            localStreams.add(localStream);
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Removes a specific local <tt>MediaStream</tt> from the associated
-     * <tt>PeerConnection</tt>.
-     *
-     * @param localStream the local <tt>MediaStream</tt> from the associated
-     *                    <tt>PeerConnection</tt>
-     * @return <tt>true</tt> if removing the specified <tt>mediaStream</tt> from
-     * this instance resulted in a modification of its internal list of local
-     * <tt>MediaStream</tt>s; otherwise, <tt>false</tt>
-     */
-    boolean removeStream(MediaStream localStream) {
-        if (peerConnection != null) {
-            peerConnection.removeStream(localStream);
-        }
-
-        return localStreams.remove(localStream);
     }
 
     PeerConnection getPeerConnection() {
@@ -105,19 +72,10 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         // Close the PeerConnection first to stop any events.
         peerConnection.close();
 
-        // PeerConnection.dispose() calls MediaStream.dispose() on all local
-        // MediaStreams added to it and the app may crash if a local MediaStream
-        // is added to multiple PeerConnections. In order to reduce the risks of
-        // an app crash, remove all local MediaStreams from the associated
-        // PeerConnection so that it doesn't attempt to dispose of them.
-        for (MediaStream localStream : new ArrayList<>(localStreams)) {
-            removeStream(localStream);
-        }
-
         // Remove video track adapters
-        for (MediaStream stream : remoteStreams.values()) {
-            for (VideoTrack videoTrack : stream.videoTracks) {
-                videoTrackAdapters.removeAdapter(videoTrack);
+        for (MediaStreamTrack track : this.remoteTracks.values()) {
+            if (track instanceof VideoTrack) {
+                videoTrackAdapters.removeAdapter((VideoTrack) track);
             }
         }
 
@@ -136,6 +94,54 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         remoteStreams.clear();
         remoteTracks.clear();
         dataChannels.clear();
+    }
+
+
+    public synchronized int getNextTransceiverId() {
+        return transceiverNextId++;
+    }
+
+    RtpTransceiver addTransceiver(MediaStreamTrack.MediaType mediaType, RtpTransceiver.RtpTransceiverInit init) {
+        if (peerConnection == null) {
+            return null;
+        }
+
+        return peerConnection.addTransceiver(mediaType, init);
+    }
+
+    RtpTransceiver addTransceiver(MediaStreamTrack track, RtpTransceiver.RtpTransceiverInit init) {
+        if (peerConnection == null) {
+            return null;
+        }
+
+        return peerConnection.addTransceiver(track, init);
+    }
+
+    RtpSender getSender(String id) {
+        if (this.peerConnection == null) {
+            return null;
+        }
+
+        for (RtpSender sender: this.peerConnection.getSenders()) {
+            if (sender.id().equals(id)) {
+                return sender;
+            }
+        }
+
+        return null;
+    }
+
+    RtpTransceiver getTransceiver(String id) {
+        if (this.peerConnection == null) {
+            return null;
+        }
+
+        for (RtpTransceiver transceiver: this.peerConnection.getTransceivers()) {
+            if (transceiver.getSender().id().equals(id)) {
+                return transceiver;
+            }
+        }
+        return null;
     }
 
     WritableMap createDataChannel(String label, ReadableMap config) {
@@ -294,120 +300,6 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         webRTCModule.sendEvent("peerConnectionIceGatheringChanged", params);
     }
 
-    private String getReactTagForStream(MediaStream mediaStream) {
-        for (Iterator<Map.Entry<String, MediaStream>> i
-             = remoteStreams.entrySet().iterator();
-             i.hasNext(); ) {
-            Map.Entry<String, MediaStream> e = i.next();
-            if (e.getValue().equals(mediaStream)) {
-                return e.getKey();
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public void onAddStream(MediaStream mediaStream) {
-        String streamReactTag = null;
-        String streamId = mediaStream.getId();
-        // The native WebRTC implementation has a special concept of a default
-        // MediaStream instance with the label default that the implementation
-        // reuses.
-        if ("default".equals(streamId)) {
-            for (Map.Entry<String, MediaStream> e : remoteStreams.entrySet()) {
-                if (e.getValue().equals(mediaStream)) {
-                    streamReactTag = e.getKey();
-                    break;
-                }
-            }
-        }
-
-        if (streamReactTag == null) {
-            streamReactTag = UUID.randomUUID().toString();
-            remoteStreams.put(streamReactTag, mediaStream);
-        }
-
-        WritableMap params = Arguments.createMap();
-        params.putInt("id", id);
-        params.putString("streamId", streamId);
-        params.putString("streamReactTag", streamReactTag);
-
-        WritableArray tracks = Arguments.createArray();
-
-        for (int i = 0; i < mediaStream.videoTracks.size(); i++) {
-            VideoTrack track = mediaStream.videoTracks.get(i);
-            String trackId = track.id();
-
-            remoteTracks.put(trackId, track);
-
-            WritableMap trackInfo = Arguments.createMap();
-            trackInfo.putString("id", trackId);
-            trackInfo.putString("label", "Video");
-            trackInfo.putString("kind", track.kind());
-            trackInfo.putBoolean("enabled", track.enabled());
-            trackInfo.putString("readyState", track.state().toString());
-            trackInfo.putBoolean("remote", true);
-            tracks.pushMap(trackInfo);
-
-            videoTrackAdapters.addAdapter(track);
-        }
-        for (int i = 0; i < mediaStream.audioTracks.size(); i++) {
-            AudioTrack track = mediaStream.audioTracks.get(i);
-            String trackId = track.id();
-
-            remoteTracks.put(trackId, track);
-
-            WritableMap trackInfo = Arguments.createMap();
-            trackInfo.putString("id", trackId);
-            trackInfo.putString("label", "Audio");
-            trackInfo.putString("kind", track.kind());
-            trackInfo.putBoolean("enabled", track.enabled());
-            trackInfo.putString("readyState", track.state().toString());
-            trackInfo.putBoolean("remote", true);
-            tracks.pushMap(trackInfo);
-        }
-        params.putArray("tracks", tracks);
-
-        SessionDescription newSdp = peerConnection.getRemoteDescription();
-        WritableMap newSdpMap = Arguments.createMap();
-        newSdpMap.putString("type", newSdp.type.canonicalForm());
-        newSdpMap.putString("sdp", newSdp.description);
-        params.putMap("sdp", newSdpMap);
-
-        webRTCModule.sendEvent("peerConnectionAddedStream", params);
-    }
-
-    @Override
-    public void onRemoveStream(MediaStream mediaStream) {
-        String streamReactTag = getReactTagForStream(mediaStream);
-        if (streamReactTag == null) {
-            Log.w(TAG, "onRemoveStream - no remote stream for id: " + mediaStream.getId());
-            return;
-        }
-
-        for (VideoTrack track : mediaStream.videoTracks) {
-            this.videoTrackAdapters.removeAdapter(track);
-            this.remoteTracks.remove(track.id());
-        }
-        for (AudioTrack track : mediaStream.audioTracks) {
-            this.remoteTracks.remove(track.id());
-        }
-
-        this.remoteStreams.remove(streamReactTag);
-
-        WritableMap params = Arguments.createMap();
-        params.putInt("id", id);
-        params.putString("streamId", streamReactTag);
-
-        SessionDescription newSdp = peerConnection.getRemoteDescription();
-        WritableMap newSdpMap = Arguments.createMap();
-        newSdpMap.putString("type", newSdp.type.canonicalForm());
-        newSdpMap.putString("sdp", newSdp.description);
-        params.putMap("sdp", newSdpMap);
-
-        webRTCModule.sendEvent("peerConnectionRemovedStream", params);
-    }
-
     @Override
     public void onDataChannel(DataChannel dataChannel) {
         final String reactTag  = UUID.randomUUID().toString();
@@ -452,9 +344,111 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         webRTCModule.sendEvent("peerConnectionSignalingStateChanged", params);
     }
 
+    /**
+     * Triggered when a new track is signaled by the remote peer, as a result of
+     * setRemoteDescription.
+     */
     @Override
     public void onAddTrack(final RtpReceiver receiver, final MediaStream[] mediaStreams) {
         Log.d(TAG, "onAddTrack");
+
+        ThreadUtils.runOnExecutor(() -> {
+            RtpTransceiver transceiver = null;
+            for(RtpTransceiver t: this.peerConnection.getTransceivers()) {
+                if (Objects.equals(t.getReceiver().id(), receiver.id())) {
+                    transceiver = t;
+                    break;
+                }
+            }
+
+            if (transceiver == null) {
+                return;
+            }
+
+            final MediaStreamTrack track = receiver.track();
+
+            if (remoteTracks.containsKey(track.id())) {
+                // Unlike in the WebRTC spec, the libwebrtc native implementation
+                // fires onTrack on every sRD which has an active receiving transceiver.
+                // So, if we are already keeping track of this transceiver, ignore the event.
+                return;
+            }
+
+            if (track.kind().equals(MediaStreamTrack.VIDEO_TRACK_KIND)){
+                videoTrackAdapters.addAdapter((VideoTrack) track);
+            }
+            remoteTracks.put(track.id(), track);
+
+            WritableMap params = Arguments.createMap();
+            WritableArray streams = Arguments.createArray();
+
+            for (MediaStream stream : mediaStreams) {
+                // Getting the streamReactTag
+                String streamReactTag = null;
+                for (Map.Entry<String, MediaStream> e : remoteStreams.entrySet()) {
+                    if (e.getValue().equals(stream)) {
+                        streamReactTag = e.getKey();
+                        break;
+                    }
+                }
+                if (streamReactTag == null) {
+                    streamReactTag = UUID.randomUUID().toString();
+                    remoteStreams.put(streamReactTag, stream);
+                }
+                streams.pushMap(SerializeUtils.serializeStream(id, streamReactTag, stream));
+            }
+
+            params.putArray("streams", streams);
+            params.putMap("receiver", SerializeUtils.serializeReceiver(id, receiver));
+            params.putInt("transceiverOrder", getNextTransceiverId());
+            params.putMap("transceiver", SerializeUtils.serializeTransceiver(id, transceiver));
+
+            params.putInt("id", this.id);
+
+            webRTCModule.sendEvent("peerConnectionOnTrack", params);
+        });
+    }
+
+    /**
+     * Triggered when the signaling from SetRemoteDescription indicates that a transceiver
+     * will be receiving media from a remote endpoint. This is only called if UNIFIED_PLAN
+     * semantics are specified. The transceiver will be disposed automatically.
+     */
+    @Override
+    public void onTrack(final RtpTransceiver transceiver) {
+    }
+
+    /*
+     * Triggered when a previously added remote track is removed by the remote
+     * peer, as a result of setRemoteDescription.
+     */
+    @Override
+    public void onRemoveTrack(RtpReceiver receiver){
+        // According to the W3C spec, we need to send out
+        // the track Id so that we can remove it from the MediaStream objects stored
+        // at the JS layer, which are the same stream objects passed down to
+        // the `track` event.
+        ThreadUtils.runOnExecutor(() -> {
+            MediaStreamTrack track = receiver.track();
+            WritableMap params = Arguments.createMap();
+            params.putInt("id", this.id);
+            params.putString("trackId", track.id());
+
+            webRTCModule.sendEvent("peerConnectionOnRemoveTrack", params);
+
+        });
+    };
+
+    // This is only added to compile. Plan B is not supported anymore.
+    @Override
+    public void onRemoveStream(MediaStream stream) {
+
+    }
+
+    // This is only added to compile. Plan B is not supported anymore.
+    @Override
+    public void onAddStream(MediaStream stream) {
+
     }
 
     @Nullable
@@ -528,4 +522,5 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         }
         return null;
     }
+
 }

--- a/android/src/main/java/com/oney/WebRTCModule/SerializeUtils.java
+++ b/android/src/main/java/com/oney/WebRTCModule/SerializeUtils.java
@@ -1,0 +1,279 @@
+package com.oney.WebRTCModule;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.webrtc.*;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableArray;
+
+public class SerializeUtils {
+  
+    /**
+     * Serialization APIs
+     */
+
+    public static ReadableMap serializeVideoCodecInfo(VideoCodecInfo info) {
+        WritableMap params = Arguments.createMap();
+        params.putString("mimeType", "video/" + info.name);
+        return params;
+    }
+
+    public static ReadableMap serializeStream(int pcId, String streamReactTag, MediaStream stream) {
+
+        WritableMap params = Arguments.createMap();
+        params.putString("streamId", stream.getId());
+        params.putString("streamReactTag", streamReactTag);
+
+        WritableArray tracks = Arguments.createArray();
+
+        for (VideoTrack track: stream.videoTracks) {
+            tracks.pushMap(SerializeUtils.serializeTrack(pcId, track));
+        }
+        for (AudioTrack track: stream.audioTracks) {
+            tracks.pushMap(SerializeUtils.serializeTrack(pcId, track));
+        }
+
+        params.putArray("tracks", tracks);
+
+        return params;
+    }
+
+    public static String serializeDirection(RtpTransceiver.RtpTransceiverDirection src) {
+        switch(src) {
+            case INACTIVE:
+                return "inactive";
+            case RECV_ONLY:
+                return "recvonly";
+            case SEND_ONLY:
+                return "sendonly";
+            case SEND_RECV:
+                return "sendrecv";
+            case STOPPED:
+                return "stopped";
+            default:
+                throw new Error("Invalid direction");
+        }
+    }
+
+    public static ReadableMap serializeTrack(int pcId, MediaStreamTrack track) {
+        WritableMap trackInfo = Arguments.createMap();
+        trackInfo.putString("id", track.id());
+        trackInfo.putInt("peerConnectionId", pcId);
+        trackInfo.putString("kind", track.kind());
+        trackInfo.putBoolean("enabled", track.enabled());
+        trackInfo.putString("readyState", track.state().toString().toLowerCase());
+        trackInfo.putBoolean("remote", true);
+        return trackInfo;
+    }
+
+    /**
+     * This method is currently missing serializing DtmfSender
+     * and transport.
+     * TODO: Add transport and dtmf fields to the serialized sender to match the web APIs.
+     */
+    public static ReadableMap serializeSender(int id, RtpSender sender) {
+        WritableMap res = Arguments.createMap();
+        res.putString("id", sender.id());
+        res.putInt("peerConnectionId", id);
+        if (sender.track() != null) {
+            res.putMap("track", SerializeUtils.serializeTrack(id, sender.track()));
+        }
+        res.putMap("rtpParameters", SerializeUtils.serializeRtpParameters(sender.getParameters()));
+        return res;
+    }
+
+    public static ReadableMap serializeReceiver(int id, RtpReceiver receiver) {
+        WritableMap res = Arguments.createMap();
+        res.putString("id", receiver.id());
+        res.putInt("peerConnectionId", id);
+        res.putMap("track", SerializeUtils.serializeTrack(id, receiver.track()));
+        return res;
+    }
+
+    public static ReadableMap serializeTransceiver(int id, RtpTransceiver transceiver) {
+        WritableMap res = Arguments.createMap();
+        res.putString("id", transceiver.getSender().id());
+        res.putInt("peerConnectionId", id);
+        String mid = transceiver.getMid();
+        res.putString("mid", mid);
+        res.putString("direction", serializeDirection(transceiver.getDirection()));
+        RtpTransceiver.RtpTransceiverDirection currentDirection = transceiver.getCurrentDirection();
+        if (currentDirection != null) {
+            res.putString("currentDirection", SerializeUtils.serializeDirection(transceiver.getCurrentDirection()));
+        }
+        res.putBoolean("isStopped", transceiver.isStopped());
+        res.putMap("receiver", SerializeUtils.serializeReceiver(id, transceiver.getReceiver()));
+        res.putMap("sender", SerializeUtils.serializeSender(id, transceiver.getSender()));
+        return res;
+    }
+
+    public static ReadableMap serializeRtpParameters(RtpParameters params) {
+      if (params == null) return null;
+
+      WritableMap result = Arguments.createMap();
+      WritableArray encodings = Arguments.createArray();
+      WritableArray codecs = Arguments.createArray();
+      WritableArray headerExtensions = Arguments.createArray();
+      WritableMap rtcp = Arguments.createMap();
+
+      
+      // Preparing RTCP
+      rtcp.putString("cname", params.getRtcp().getCname());
+      rtcp.putBoolean("reducedSize", params.getRtcp().getReducedSize());
+      
+      
+      // Preparing header extensions
+      params.getHeaderExtensions().forEach(extension -> {
+        WritableMap extensionMap = Arguments.createMap();
+        extensionMap.putInt("id", extension.getId());
+        extensionMap.putString("uri", extension.getUri());
+        extensionMap.putBoolean("encrypted", extension.getEncrypted());
+        headerExtensions.pushMap(extensionMap);
+      });
+
+      // Preparing encodings
+      params.encodings.forEach(encoding -> {
+        WritableMap encodingMap = Arguments.createMap();
+        encodingMap.putBoolean("active", encoding.active);
+        // Since they return integer objects that are nullable,
+        // while the map does not accept nullable integer values.
+        if (encoding.maxBitrateBps != null) {
+          encodingMap.putInt("maxBitrate", encoding.maxBitrateBps);
+        }
+        if (encoding.maxFramerate != null) {
+          encodingMap.putInt("maxFramerate", encoding.maxFramerate);
+        }
+        if (encoding.scaleResolutionDownBy != null) {
+          encodingMap.putDouble("scaleResolutionDownBy", encoding.scaleResolutionDownBy);
+        }
+        encodings.pushMap(encodingMap);
+      });
+
+      // Preparing codecs
+      params.codecs.forEach(codec -> {
+        WritableMap codecMap = Arguments.createMap();
+        WritableMap sdpFmptLineParams = Arguments.createMap();
+        codecMap.putInt("payloadType", codec.payloadType);
+        codecMap.putString("mimeType", codec.name);
+        codecMap.putInt("clockRate", codec.clockRate);
+        if (codec.numChannels != null) {
+          codecMap.putInt("channels", codec.numChannels);
+        }
+        // Serializing sdpFmptLine. 
+        codec.parameters.forEach((k, v) -> {
+          sdpFmptLineParams.putString((String) k, (String) v);
+        });
+        codecMap.putMap("sdpFmtpLine", sdpFmptLineParams);
+        codecs.pushMap(codecMap);
+      });
+
+      result.putString("transactionId", params.transactionId);
+      result.putMap("rtcp", rtcp);
+      result.putArray("encodings", encodings);
+      result.putArray("codecs", codecs);
+      result.putArray("headerExtensions", headerExtensions);
+      if (params.degradationPreference != null) {
+        result.putString("degradationPreference", params.degradationPreference
+          .toString());
+      }
+
+      return result;
+    }
+
+    /**
+     * Parsing APIs
+     */
+
+    public static RtpParameters updateRtpParameters(ReadableMap updateParams, RtpParameters rtpParams) {
+      
+      // Preparing encodings
+      ReadableArray encodingsArray = updateParams.getArray("encodings");
+      List<RtpParameters.Encoding> encodings = rtpParams.encodings;
+      if (encodingsArray.size() != encodings.size()) {
+        return null;
+      }
+
+      for (int i = 0; i < encodingsArray.size(); i++) {
+        ReadableMap encodingUpdate = encodingsArray.getMap(i);
+        RtpParameters.Encoding encoding = encodings.get(i);
+        // Dealing with nullable Integers
+        Integer maxBitrate = encodingUpdate.hasKey("maxBitrate")? encodingUpdate.getInt("maxBitrate") : null;
+        Integer maxFramerate = encodingUpdate.hasKey("maxFramerate")? encodingUpdate.getInt("maxFramerate") : null;
+        Double scaleResolutionDownBy = encodingUpdate.hasKey("scaleResolutionDownBy")? 
+          encodingUpdate.getDouble("scaleResolutionDownBy") : null;
+        
+        encoding.active = encodingUpdate.getBoolean("active");
+        encoding.maxBitrateBps = maxBitrate;
+        encoding.maxFramerate = maxFramerate;
+        encoding.scaleResolutionDownBy = scaleResolutionDownBy;
+      }
+
+      if (updateParams.hasKey("degradationPreference")) {
+        rtpParams.degradationPreference = 
+          RtpParameters.DegradationPreference.valueOf(updateParams.getString("degradationPreference"));
+      }
+
+      return rtpParams;
+    }
+
+    public static MediaStreamTrack.MediaType parseMediaType(String type) {
+        switch(type) {
+            case "audio": 
+                return MediaStreamTrack.MediaType.MEDIA_TYPE_AUDIO;
+            case "video":
+                return MediaStreamTrack.MediaType.MEDIA_TYPE_VIDEO;
+            default:
+                throw new Error("Unknown media type");
+        }
+    }
+    
+    public static RtpTransceiver.RtpTransceiverDirection parseDirection(String src) {
+        switch (src) {
+            case "sendrecv":
+                return RtpTransceiver.RtpTransceiverDirection.SEND_RECV;
+            case "sendonly":
+                return RtpTransceiver.RtpTransceiverDirection.SEND_ONLY;
+            case "recvonly":
+                return RtpTransceiver.RtpTransceiverDirection.RECV_ONLY;
+            case "inactive":
+                return RtpTransceiver.RtpTransceiverDirection.INACTIVE;
+            // Here we ignore the "stopped" direction because user code should
+            // never set it.
+        }
+        throw new Error("Invalid direction");
+    }
+
+    public static RtpTransceiver.RtpTransceiverInit parseTransceiverOptions(ReadableMap map) {
+        RtpTransceiver.RtpTransceiverDirection direction = RtpTransceiver.RtpTransceiverDirection.INACTIVE;
+        ArrayList<String> streamIds = new ArrayList<>();
+        if (map != null) {
+            if (map.hasKey("direction")) {
+                String directionRaw = map.getString("direction");
+                if (directionRaw != null) {
+                    direction = SerializeUtils.parseDirection(directionRaw);
+                }
+            }
+            if (map.hasKey("streamIds")) {
+                ReadableArray rawStreamIds = map.getArray("streamIds");
+                if (rawStreamIds != null) {
+                    for (int i = 0; i < rawStreamIds.size(); i++) {
+                        streamIds.add(rawStreamIds.getString(i));
+                    }
+                }
+            }
+        }
+
+        return new RtpTransceiver.RtpTransceiverInit(direction, streamIds);
+    }
+
+}

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
@@ -37,6 +38,10 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     static final String TAG = WebRTCModule.class.getCanonicalName();
 
     PeerConnectionFactory mFactory;
+    VideoEncoderFactory mVideoEncoderFactory;
+    VideoDecoderFactory mVideoDecoderFactory;
+
+    // Need to expose the peer connection codec factories here to get capabilities
     private final SparseArray<PeerConnectionObserver> mPeerConnectionObservers;
     final Map<String, MediaStream> localStreams;
 
@@ -132,6 +137,10 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 .setVideoDecoderFactory(decoderFactory)
                 .createPeerConnectionFactory();
 
+        // Saving the encoder and decoder factories to get codec info later when needed
+        mVideoEncoderFactory = encoderFactory;
+        mVideoDecoderFactory = decoderFactory;
+
         getUserMediaImpl = new GetUserMediaImpl(this, reactContext);
     }
 
@@ -146,10 +155,20 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         return (pco == null) ? null : pco.getPeerConnection();
     }
 
-    void sendEvent(String eventName, @Nullable WritableMap params) {
+    void sendEvent(String eventName, @Nullable ReadableMap params) {
         getReactApplicationContext()
             .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
             .emit(eventName, params);
+    }
+
+    void sendError(String eventName, String funcName, @Nullable String message, @Nullable ReadableMap info) {
+        WritableMap errorInfo = Arguments.createMap();
+        errorInfo.putString("func", funcName);
+        if (info != null)
+            errorInfo.putMap("info", info);
+        if (message != null)
+            errorInfo.putString("message", message);
+        sendEvent(eventName, errorInfo);
     }
 
     private PeerConnection.IceServer createIceServer(String url) {
@@ -206,8 +225,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         // Required for perfect negotiation.
         conf.enableImplicitRollback = true;
 
-        // Plan B, just a little longer.
-        conf.sdpSemantics = PeerConnection.SdpSemantics.PLAN_B;
+        conf.sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN;
 
         if (map == null) {
             return conf;
@@ -438,7 +456,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         }
     }
 
-    private MediaStreamTrack getTrack(String trackId) {
+    public MediaStreamTrack getTrack(String trackId) {
         MediaStreamTrack track = getLocalTrack(trackId);
 
         if (track == null) {
@@ -479,6 +497,255 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         }
 
         return mediaConstraints;
+    }
+
+
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap peerConnectionAddTransceiver(int id, ReadableMap options) {
+        try {
+            return (WritableMap) ThreadUtils.submitToExecutor((Callable<Object>) () -> {
+                PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                if (pco == null) {
+                    Log.d(TAG, "peerConnectionAddTransceiver() peerConnection is null");
+                    return null;
+                }
+
+                RtpTransceiver transceiver = null;
+                if (options.hasKey("type")) {
+                    String kind = options.getString("type");
+                    transceiver = pco.addTransceiver(SerializeUtils.parseMediaType(kind),
+                        SerializeUtils.parseTransceiverOptions(options.getMap("init")));
+                } else if (options.hasKey("trackId")) {
+                    String trackId = options.getString("trackId");
+                    MediaStreamTrack track = getTrack(trackId);
+                    transceiver = pco.addTransceiver(track,
+                        SerializeUtils.parseTransceiverOptions(options.getMap("init")));
+
+                } else {
+                    // This should technically never happen as the JS side checks for that.
+                    Log.d(TAG, "peerConnectionAddTransceiver() no type nor trackId provided in options");
+                    return null;
+                }
+
+                if (transceiver == null) {
+                    Log.d(TAG, "peerConnectionAddTransceiver() Error adding transceiver");
+                    return null;
+                }
+                WritableMap params = Arguments.createMap();
+                // We need to get a unique order at which the transceiver was created
+                // to reorder the cached array of transceivers on the JS layer.
+                params.putInt("transceiverOrder", pco.getNextTransceiverId());
+                params.putMap("transceiver", SerializeUtils.serializeTransceiver(id, transceiver));
+                return params;
+            }).get();
+        } catch (InterruptedException | ExecutionException e) {
+            Log.d(TAG, "peerConnectionAddTransceiver() " + e.getMessage());
+            return null;
+        }
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap peerConnectionAddTrack(int id,
+                                              String trackId,
+                                              ReadableMap options) {
+        try {
+            return (WritableMap) ThreadUtils.submitToExecutor((Callable<Object>) () -> {
+                PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                if (pco == null) {
+                    Log.d(TAG, "peerConnectionAddTrack() peerConnection is null");
+                    return null;
+                }
+
+                MediaStreamTrack track = getLocalTrack(trackId);
+                if (track == null) {
+                    Log.w(TAG, "peerConnectionAddTrack() couldn't find track " + trackId);
+                    return null;
+                }
+
+                List<String> streamIds = new ArrayList<>();
+                if (options.hasKey("streamIds")) {
+                    ReadableArray rawStreamIds = options.getArray("streamIds");
+                    if (rawStreamIds != null) {
+                        for (int i = 0; i < rawStreamIds.size(); i++) {
+                            streamIds.add(rawStreamIds.getString(i));
+                        }
+                    }
+                }
+                RtpSender sender = pco.getPeerConnection().addTrack(track, streamIds);
+
+                // Need to get the corresponding transceiver as well
+                RtpTransceiver transceiver = pco.getTransceiver(sender.id());
+
+                // We need the transceiver creation order to reorder the transceivers array
+                // in the JS layer.
+                WritableMap params = Arguments.createMap();
+                params.putInt("transceiverOrder", pco.getNextTransceiverId());
+                params.putMap("transceiver", SerializeUtils.serializeTransceiver(id, transceiver));
+                params.putMap("sender", SerializeUtils.serializeSender(id, sender));
+                return params;
+            }).get();
+        } catch (InterruptedException | ExecutionException e) {
+            Log.d(TAG, "peerConnectionAddTrack() " + e.getMessage());
+            return null;
+        }
+    }
+
+    @ReactMethod
+    public void senderSetParameters(int id, String senderId, ReadableMap options, Promise promise) {
+        ThreadUtils.runOnExecutor(() ->{
+            try {
+                PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                if (pco == null) {
+                    Log.d(TAG, "senderSetParameters() peerConnectionObserver is null");
+                    promise.reject(new Exception("Peer Connection is not initialized"));
+                    return;
+                }
+
+                RtpSender sender = pco.getSender(senderId);
+                if (sender == null) {
+                    Log.w(TAG, "senderSetParameters() sender is null");
+                    promise.reject(new Exception("Could not get sender"));
+                    return;
+                }
+
+                RtpParameters params = sender.getParameters();
+                params = SerializeUtils.updateRtpParameters(options, params);
+                sender.setParameters(params);
+                promise.resolve(SerializeUtils.serializeRtpParameters(sender.getParameters()));
+            } catch (Exception e) {
+                Log.d(TAG, "senderSetParameters: " + e.getMessage());
+                promise.reject(e);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void peerConnectionRemoveTrack(int id, String senderId) {
+            ThreadUtils.runOnExecutor(() -> {
+                WritableMap identifier = Arguments.createMap();
+                identifier.putInt("peerConnectionId", id);
+                identifier.putString("senderId", senderId);
+                try {
+                    PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                    if (pco == null) {
+                        Log.d(TAG, "peerConnectionRemoveTrack() peerConnection is null");
+                        sendError("peerConnectionOnError", "removeTrack", "Peer Connection is not initialized", null);
+                        return;
+                    }
+                    RtpSender sender = pco.getSender(senderId);
+                    if (sender == null) {
+                        Log.w(TAG, "peerConnectionRemoveTrack() sender is null");
+                        sendError("peerConnectionOnError", "removeTrack", "Sender is null", null);
+                        return;
+                    }
+
+                    boolean successful = pco.getPeerConnection().removeTrack(sender);
+                    if (successful) {
+                        sendEvent("peerConnectionOnRemoveTrackSuccessful", identifier);
+                        return;
+                    }
+                    sendError("peerConnectionOnError", "removeTrack", "Internal Error", identifier);
+                } catch (Exception e) {
+                    Log.d(TAG, "peerConnectionRemoveTrack() " + e.getMessage());
+                    sendError("peerConnectionOnError", "removeTrack", e.getMessage(), identifier);
+                }
+            });
+    }
+
+    @ReactMethod
+    public void transceiverStop(int id,
+                                String senderId) {
+        ThreadUtils.runOnExecutor(() -> {
+            WritableMap identifier = Arguments.createMap();
+            identifier.putInt("peerConnectionId", id);
+            identifier.putString("transceiverId", senderId);
+            try {
+                PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                if (pco == null) {
+                    Log.d(TAG, "transceiverStop() peerConnectionObserver is null");
+                    // Cannot really report an error specific to RTCRtpTransceiver as the peer connection
+                    // hasn't really been initialized, this call from the web API should technically
+                    // not happen unless both peer connection and transceivers are initialized properly
+                    // That is why constructors or create methods should always be synchronous.
+                    return;
+                }
+                RtpTransceiver transceiver = pco.getTransceiver(senderId);
+
+                transceiver.stopStandard();
+                sendEvent("transceiverStopSuccessful", identifier);
+            } catch (Exception e) {
+                Log.d(TAG, "transceiverStop(): " + e.getMessage());
+                sendError("transceiverOnError", "stopTransceiver", e.getMessage(), identifier);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void senderReplaceTrack(int id,
+                                   String senderId,
+                                   String trackId,
+                                   Promise promise) {
+        ThreadUtils.runOnExecutor(() -> {
+            try {
+                PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                if (pco == null) {
+                    Log.d(TAG, "senderReplaceTrack() peerConnectionObserver is null");
+                    promise.reject(new Exception("Peer Connection is not initialized"));
+                    return;
+                }
+
+                RtpSender sender = pco.getSender(senderId);
+                if (sender == null) {
+                    Log.w(TAG, "senderReplaceTrack() sender is null");
+                    promise.reject(new Exception("Could not get sender"));
+                    return;
+                }
+
+                MediaStreamTrack track = getLocalTrack(trackId);
+                sender.setTrack(track, false);
+                promise.resolve(true);
+            } catch (Exception e) {
+                Log.d(TAG, "senderReplaceTrack(): " + e.getMessage());
+                promise.reject(e);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void transceiverSetDirection(int id,
+                                        String senderId,
+                                        String direction) {
+
+        ThreadUtils.runOnExecutor(() -> {
+            WritableMap identifier = Arguments.createMap();
+            WritableMap params = Arguments.createMap();
+            identifier.putInt("peerConnectionId", id);
+            identifier.putString("transceiverId", senderId);
+            try {
+                PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+                if (pco == null) {
+                    Log.d(TAG, "transceiverSetDirection() peerConnectionObserver is null");
+                    // Cannot really report an error specific to RTCRtpSender as the peer connection
+                    // hasn't really been initialized, this call from the web API should technically
+                    // not happen unless both peer connection and sender are initialized
+                    return;
+                }
+                RtpTransceiver transceiver = pco.getTransceiver(senderId);
+                if (transceiver == null){
+                    Log.d(TAG, "transceiverSetDirection() transceiver is null");
+                    return;
+                }
+
+                RtpTransceiver.RtpTransceiverDirection oldDirection = transceiver.getDirection();
+                params.putString("oldDirection", SerializeUtils.serializeDirection(oldDirection));
+                transceiver.setDirection(SerializeUtils.parseDirection(direction));
+            } catch (Exception e) {
+                Log.d(TAG, "transceiverSetDirection(): " + e.getMessage());
+                params.putMap("identifiers", identifier);
+                sendError("transceiverOnError", "setDirection", e.getMessage(), params);
+            }
+        });
     }
 
     @ReactMethod
@@ -556,15 +823,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 Log.d(TAG, "mediaStreamRelease() stream is null");
                 return;
             }
-
             localStreams.remove(id);
-
-            // MediaStream.dispose() may be called without an exception only if
-            // it's no longer added to any PeerConnection.
-            for (int i = 0, size = mPeerConnectionObservers.size(); i < size; i++) {
-                mPeerConnectionObservers.valueAt(i).removeStream(stream);
-            }
-
             stream.dispose();
         });
     }
@@ -607,6 +866,34 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         });
     }
 
+    /**
+     * This serializes the transceivers current direction and mid and returns them
+     * for update when an sdp negotiation/renegotiation happens
+     */
+    private ReadableArray getTransceiversInfo(int id) {
+        PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+        if (pco == null) {
+            return null;
+        }
+        PeerConnection peerConnection = pco.getPeerConnection();
+        WritableArray transceiverUpdates = Arguments.createArray();
+        for(RtpTransceiver transceiver: peerConnection.getTransceivers()) {
+            RtpTransceiver.RtpTransceiverDirection direction = transceiver.getCurrentDirection();
+            if (direction == null) continue;
+            String directionSerialized = SerializeUtils.serializeDirection(direction);
+            WritableMap transceiverUpdate = Arguments.createMap();
+            transceiverUpdate.putString("transceiverId", transceiver.getSender().id());
+            transceiverUpdate.putInt("peerConnectionId", id);
+            transceiverUpdate.putString("mid", transceiver.getMid());
+            transceiverUpdate.putString("currentDirection", directionSerialized);
+            transceiverUpdate.putMap("senderRtpParameters",
+                SerializeUtils.serializeRtpParameters(
+                    transceiver.getSender().getParameters()));
+            transceiverUpdates.pushMap(transceiverUpdate);
+        }
+        return transceiverUpdates;
+    }
+
     @ReactMethod
     public void peerConnectionSetConfiguration(ReadableMap configuration,
                                                int id) {
@@ -617,36 +904,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 return;
             }
             peerConnection.setConfiguration(parseRTCConfiguration(configuration));
-        });
-    }
-
-    @ReactMethod
-    public void peerConnectionAddStream(String streamId, int id) {
-        ThreadUtils.runOnExecutor(() -> {
-            MediaStream mediaStream = localStreams.get(streamId);
-            if (mediaStream == null) {
-                Log.d(TAG, "peerConnectionAddStream() mediaStream is null");
-                return;
-            }
-            PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
-            if (pco == null || !pco.addStream(mediaStream)) {
-                Log.e(TAG, "peerConnectionAddStream() failed");
-            }
-        });
-    }
-
-    @ReactMethod
-    public void peerConnectionRemoveStream(String streamId, int id) {
-        ThreadUtils.runOnExecutor(() -> {
-            MediaStream mediaStream = localStreams.get(streamId);
-            if (mediaStream == null) {
-                Log.d(TAG, "peerConnectionRemoveStream() mediaStream is null");
-                return;
-            }
-            PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
-            if (pco == null || !pco.removeStream(mediaStream)) {
-                Log.e(TAG, "peerConnectionRemoveStream() failed");
-            }
         });
     }
 
@@ -672,8 +929,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onCreateSuccess(SessionDescription sdp) {
                     WritableMap params = Arguments.createMap();
-                    params.putString("sdp", sdp.description);
-                    params.putString("type", sdp.type.canonicalForm());
+                    WritableMap sdpInfo = Arguments.createMap();
+                    sdpInfo.putString("sdp", sdp.description);
+                    sdpInfo.putString("type", sdp.type.canonicalForm());
+                    params.putArray("transceiversInfo", getTransceiversInfo(id));
+                    params.putMap("sdpInfo", sdpInfo);
                     callback.invoke(true, params);
                 }
 
@@ -708,8 +968,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onCreateSuccess(SessionDescription sdp) {
                     WritableMap params = Arguments.createMap();
-                    params.putString("sdp", sdp.description);
-                    params.putString("type", sdp.type.canonicalForm());
+                    WritableMap sdpInfo = Arguments.createMap();
+                    sdpInfo.putString("sdp", sdp.description);
+                    sdpInfo.putString("type", sdp.type.canonicalForm());
+                    params.putArray("transceiversInfo", getTransceiversInfo(id));
+                    params.putMap("sdpInfo", sdpInfo);
                     callback.invoke(true, params);
                 }
 
@@ -743,9 +1006,12 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 public void onSetSuccess() {
                     SessionDescription newSdp = peerConnection.getLocalDescription();
                     WritableMap newSdpMap = Arguments.createMap();
+                    WritableMap params = Arguments.createMap();
                     newSdpMap.putString("type", newSdp.type.canonicalForm());
                     newSdpMap.putString("sdp", newSdp.description);
-                    promise.resolve(newSdpMap);
+                    params.putMap("sdpInfo", newSdpMap);
+                    params.putArray("transceiversInfo", getTransceiversInfo(pcId));
+                    promise.resolve(params);
                 }
 
                 @Override
@@ -797,9 +1063,12 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 public void onSetSuccess() {
                     SessionDescription newSdp = peerConnection.getRemoteDescription();
                     WritableMap newSdpMap = Arguments.createMap();
+                    WritableMap params = Arguments.createMap();
                     newSdpMap.putString("type", newSdp.type.canonicalForm());
                     newSdpMap.putString("sdp", newSdp.description);
-                    callback.invoke(true, newSdpMap);
+                    params.putArray("transceiversInfo", getTransceiversInfo(id));
+                    params.putMap("sdpInfo", newSdpMap);
+                    callback.invoke(true, params);
                 }
 
                 @Override
@@ -812,6 +1081,46 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 }
             }, sdp);
         });
+    }
+
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap receiverGetCapabilities() {
+        try {
+            return (WritableMap) ThreadUtils.submitToExecutor((Callable<Object>) () -> {
+                VideoCodecInfo[] videoCodecInfos = mVideoDecoderFactory.getSupportedCodecs();
+                WritableMap params = Arguments.createMap();
+                WritableArray codecs = Arguments.createArray();
+                for(VideoCodecInfo codecInfo: videoCodecInfos) {
+                    codecs.pushMap(SerializeUtils.serializeVideoCodecInfo(codecInfo));
+                }
+                params.putArray("codecs", codecs);
+                return params;
+            }).get();
+        } catch (ExecutionException | InterruptedException e) {
+            Log.d(TAG, "receiverGetCapabilities() " + e.getMessage());
+            return null;
+        }
+    }
+
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public WritableMap senderGetCapabilities() {
+        try {
+            return (WritableMap) ThreadUtils.submitToExecutor((Callable<Object>) () -> {
+                VideoCodecInfo[] videoCodecInfos = mVideoEncoderFactory.getSupportedCodecs();
+                WritableMap params = Arguments.createMap();
+                WritableArray codecs = Arguments.createArray();
+                for(VideoCodecInfo codecInfo: videoCodecInfos) {
+                    codecs.pushMap(SerializeUtils.serializeVideoCodecInfo(codecInfo));
+                }
+                params.putArray("codecs", codecs);
+                return params;
+            }).get();
+        } catch (ExecutionException | InterruptedException e) {
+            Log.d(TAG, "senderGetCapabilities() " + e.getMessage());
+            return null;
+        }
     }
 
     @ReactMethod

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -187,8 +187,12 @@ public class WebRTCView extends ViewGroup {
                     videoTrack = videoTracks.get(0);
                 }
             }
-        }
 
+            if (videoTrack == null) {
+                Log.w(TAG, "No video stream for react tag: " + streamURL);
+            }
+        }
+        
         return videoTrack;
     }
 

--- a/ios/RCTWebRTC/RCTConvert+WebRTC.m
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.m
@@ -90,8 +90,7 @@
   // Required for perfect negotiation.
   config.enableImplicitRollback = YES;
 
-  // Plan B, just a little longer.
-  config.sdpSemantics = RTCSdpSemanticsPlanB;
+  config.sdpSemantics = RTCSdpSemanticsUnifiedPlan;
 
   if (!json) {
     return config;

--- a/ios/RCTWebRTC/SerializeUtils.h
+++ b/ios/RCTWebRTC/SerializeUtils.h
@@ -1,0 +1,25 @@
+#import <WebRTC/RTCMediaStreamTrack.h>
+#import <WebRTC/RTCRtpReceiver.h>
+#import <WebRTC/RTCRtpTransceiver.h>
+#import <WebRTC/RTCVideoCodecInfo.h>
+#import "WebRTCModule+RTCPeerConnection.h"
+
+@interface SerializeUtils : NSObject
+
++ (NSString *_Nonnull)transceiverToJSONWithPeerConnectionId: (nonnull NSNumber *) id
+                                                                   transceiver: (RTCRtpTransceiver *_Nonnull) transceiver;
++ (NSDictionary *_Nonnull)senderToJSONWithPeerConnectionId: (nonnull NSNumber *) id
+                                                        sender: (RTCRtpSender *_Nonnull) sender;
++ (NSDictionary *_Nonnull)receiverToJSONWithPeerConnectionId: (nonnull NSNumber *) id
+                                                        receiver: (RTCRtpReceiver *_Nonnull) receiver;
++ (NSDictionary *_Nonnull)trackToJSONWithPeerConnectionId: (nonnull NSNumber *) id
+                                                        track: (RTCMediaStreamTrack *_Nonnull) track;
++ (NSString *_Nonnull)serializeDirection: (RTCRtpTransceiverDirection) direction;
++ (RTCRtpTransceiverDirection) parseDirection: (NSString *_Nonnull) direction;
++ (NSDictionary *_Nonnull)parametersToJSON: (RTCRtpParameters *_Nonnull) parameters;
++ (NSMutableArray *_Nonnull)constructTransceiversInfoArrayWithPeerConnection: (RTCPeerConnection *_Nonnull) peerConnection
+                                                             peerConnectionId: (NSNumber *_Nonnull) peerConnectionId;
++ (NSDictionary *_Nonnull)streamToJSONWithPeerConnectionId: (NSNumber *_Nonnull) id
+                                                stream: (RTCMediaStream *_Nonnull) stream
+                                                streamReactTag: (NSString *_Nonnull) streamReactTag;
+@end

--- a/ios/RCTWebRTC/SerializeUtils.m
+++ b/ios/RCTWebRTC/SerializeUtils.m
@@ -1,0 +1,219 @@
+#import "SerializeUtils.h"
+
+@implementation SerializeUtils 
++ (NSDictionary *) transceiverToJSONWithPeerConnectionId: (NSNumber *) id
+                                                           transceiver:(RTCRtpTransceiver * _Nonnull) transceiver {
+    NSMutableDictionary *result = [NSMutableDictionary new];
+   
+    result[@"id"] = transceiver.sender.senderId;
+    result[@"peerConnectionId"] = id;
+    result[@"mid"] = transceiver.mid;
+    result[@"direction"] = [SerializeUtils serializeDirection: transceiver.direction];
+    
+    RTCRtpTransceiverDirection currentDirection;
+    if ([transceiver currentDirection: &currentDirection]) {
+        result[@"currentDirection"] = [SerializeUtils serializeDirection: currentDirection];
+    }
+    
+    result[@"isStopped"] = [NSNumber numberWithBool:transceiver.isStopped];
+    result[@"receiver"] = [SerializeUtils receiverToJSONWithPeerConnectionId: id receiver: transceiver.receiver];
+    result[@"sender"] = [SerializeUtils senderToJSONWithPeerConnectionId: id sender: transceiver.sender];
+                                                               
+    return result;
+}
+
++ (NSMutableArray *) constructTransceiversInfoArrayWithPeerConnection: (RTCPeerConnection *) peerConnection
+                                                   peerConnectionId: (NSNumber *) peerConnectionId {
+    NSMutableArray *transceiverUpdates = [NSMutableArray new];
+    
+    for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+        RTCRtpTransceiverDirection currentDirection;
+        if ([transceiver currentDirection: &currentDirection]) {
+            NSMutableDictionary *transceiverUpdate= [NSMutableDictionary new];
+            transceiverUpdate[@"transceiverId"] = transceiver.sender.senderId;
+            transceiverUpdate[@"peerConnectionId"] = peerConnectionId;
+            transceiverUpdate[@"mid"] = transceiver.mid;
+            NSString *currentDirectionSerialized = [SerializeUtils serializeDirection: currentDirection];
+            transceiverUpdate[@"currentDirection"] = currentDirectionSerialized;
+            transceiverUpdate[@"senderRtpParameters"] = [SerializeUtils parametersToJSON:transceiver.sender.parameters];
+            
+            [transceiverUpdates addObject:transceiverUpdate];
+        }
+    }
+                                                               
+    return transceiverUpdates;
+}
+
+
++ (NSDictionary *) senderToJSONWithPeerConnectionId: (NSNumber *) id
+                                            sender: (RTCRtpSender *) sender {
+    NSMutableDictionary *senderDictionary= [NSMutableDictionary new];
+    senderDictionary[@"id"] = sender.senderId;
+    senderDictionary[@"peerConnectionId"] = id;
+
+    if (sender.track) {
+        senderDictionary[@"track"] = [SerializeUtils trackToJSONWithPeerConnectionId: id track: sender.track];
+    }
+
+    senderDictionary[@"rtpParameters"] = [SerializeUtils parametersToJSON: sender.parameters];
+   
+   return senderDictionary;
+}
+
++ (NSDictionary *) receiverToJSONWithPeerConnectionId: (NSNumber *) id
+                                            receiver: (RTCRtpReceiver *) receiver {
+    NSMutableDictionary *receiverDictionary = [NSMutableDictionary new];
+    receiverDictionary[@"id"] = receiver.receiverId;
+    receiverDictionary[@"peerConnectionId"] = id;
+
+    if (receiver.track) {
+        receiverDictionary[@"track"] = [SerializeUtils trackToJSONWithPeerConnectionId: id track: receiver.track];
+    }
+   
+   return receiverDictionary;
+}
+
++ (NSDictionary *) parametersToJSON: (RTCRtpParameters *) params {
+    NSMutableDictionary *paramsDictionary = [NSMutableDictionary new];
+    
+    NSMutableDictionary *rtcpDictionary = [NSMutableDictionary new];
+    rtcpDictionary[@"cname"] = params.rtcp.cname;
+    rtcpDictionary[@"reducedSize"] = [NSNumber numberWithBool: params.rtcp.isReducedSize];
+    
+    NSMutableArray *headerExtensions = [NSMutableArray new];
+    
+    for (RTCRtpHeaderExtension *extension in params.headerExtensions) {
+        NSMutableDictionary *extensionDictionary = [NSMutableDictionary new];
+        extensionDictionary[@"id"] = [NSNumber numberWithInt: extension.id];
+        extensionDictionary[@"uri"] = extension.uri;
+        extensionDictionary[@"encrypted"] = [NSNumber numberWithBool: extension.isEncrypted];
+        
+        [headerExtensions addObject: extensionDictionary];
+    }
+    
+    NSMutableArray *encodings = [NSMutableArray new];
+    
+    for (RTCRtpEncodingParameters *encoding in params.encodings) {
+        NSMutableDictionary *encodingDictionary = [NSMutableDictionary new];
+        
+        encodingDictionary[@"active"] = [NSNumber numberWithBool: encoding.isActive];
+               
+        if (encoding.maxBitrateBps) {
+            encodingDictionary[@"maxBitrate"] = encoding.maxBitrateBps;
+        }
+        if (encoding.maxFramerate) {
+            encodingDictionary[@"maxFramerate"] = encoding.maxFramerate;
+        }
+        if (encoding.scaleResolutionDownBy) {
+            encodingDictionary[@"scaleResolutionDownBy"] = encoding.scaleResolutionDownBy;
+        }
+        
+        [encodings addObject: encodingDictionary];
+    }
+
+    NSMutableArray *codecs = [NSMutableArray new];
+    
+    for (RTCRtpCodecParameters *codec in params.codecs) {
+        NSMutableDictionary *codecDictionary = [NSMutableDictionary new];
+        
+        codecDictionary[@"payloadType"] = [NSNumber numberWithInt: codec.payloadType];
+        codecDictionary[@"mimeType"] = codec.name;
+        codecDictionary[@"clockRate"] = codec.clockRate;
+        
+        if (codec.numChannels) {
+            codecDictionary[@"channels"] = codec.numChannels;
+        }
+        
+        codecDictionary[@"sdpFmtpLine"] = codec.parameters;
+
+        [codecs addObject: codecDictionary];
+    }
+
+    paramsDictionary[@"transactionId"] = params.transactionId;
+    paramsDictionary[@"rtcp"] = rtcpDictionary;
+    paramsDictionary[@"headerExtensions"] = headerExtensions;
+    paramsDictionary[@"encodings"] = encodings;
+    paramsDictionary[@"codecs"] = codecs;
+    
+    if (params.degradationPreference) {
+        paramsDictionary[@"degradationPreference"] = params.degradationPreference;
+    }
+    
+    return paramsDictionary;
+}
+
++ (NSDictionary *) trackToJSONWithPeerConnectionId: (NSNumber *) id
+                                            track: (RTCMediaStreamTrack *) track {
+    NSString *readyState;
+    switch (track.readyState) {
+        case RTCMediaStreamTrackStateLive:
+            readyState = @"Live";
+        case RTCMediaStreamTrackStateEnded:
+            readyState = @"Ended";
+    }
+    
+    return @{
+        @"id": track.trackId,
+        @"peerConnectionId": id,
+        @"kind": track.kind,
+        @"enabled": [NSNumber numberWithBool:track.isEnabled],
+        @"readyState":  readyState,
+        @"remote": [NSNumber numberWithBool:YES],
+    };
+}
+
++ (NSString *) serializeDirection: (RTCRtpTransceiverDirection) direction {
+    if (direction == RTCRtpTransceiverDirectionInactive) {
+        return @"inactive";
+    } else if (direction == RTCRtpTransceiverDirectionRecvOnly) {
+        return @"recvonly";
+    } else if (direction == RTCRtpTransceiverDirectionSendOnly) {
+        return @"sendonly";
+    } else if (direction == RTCRtpTransceiverDirectionSendRecv) {
+        return @"sendrecv";
+    } else if (direction == RTCRtpTransceiverDirectionStopped) {
+        return @"stopped";
+    }
+    return nil;
+}
+
++ (RTCRtpTransceiverDirection) parseDirection: (NSString *) direction {
+    if ([direction  isEqual: @"inactive"]) {
+        return RTCRtpTransceiverDirectionInactive;
+    } else if ([direction  isEqual: @"recvonly"]) {
+        return RTCRtpTransceiverDirectionRecvOnly;
+    } else if ([direction  isEqual: @"sendonly"]) {
+        return RTCRtpTransceiverDirectionSendOnly;
+    } else if ([direction  isEqual: @"sendrecv"]) {
+        return RTCRtpTransceiverDirectionSendRecv;
+    } else if ([direction  isEqual: @"stopped"]) {
+        return RTCRtpTransceiverDirectionStopped;
+    }
+    
+    return RTCRtpTransceiverDirectionInactive;
+}
+
+
++ (NSDictionary *)streamToJSONWithPeerConnectionId: (NSNumber *) id
+                                                stream: (RTCMediaStream *) stream
+                                                streamReactTag: (NSString *) streamReactTag {
+    NSMutableDictionary *streamDictionary = [NSMutableDictionary new];
+    
+    streamDictionary[@"streamId"] = stream.streamId;
+    streamDictionary[@"streamReactTag"] = streamReactTag;
+
+    NSMutableArray *tracks = [NSMutableArray new];
+    
+    for (RTCAudioTrack *audioTrack in stream.audioTracks) {
+        [tracks addObject:[SerializeUtils trackToJSONWithPeerConnectionId:id track:audioTrack]];
+    }
+    
+    for (RTCVideoTrack *videoTrack in stream.videoTracks) {
+        [tracks addObject:[SerializeUtils trackToJSONWithPeerConnectionId:id track:videoTrack]];
+    }
+                                                    
+    streamDictionary[@"tracks"] = tracks;
+    
+    return streamDictionary;
+}
+@end

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -19,11 +19,15 @@
 #import <WebRTC/RTCIceCandidate.h>
 #import <WebRTC/RTCSessionDescription.h>
 #import <WebRTC/RTCStatisticsReport.h>
+#import <WebRTC/RTCMediaStreamTrack.h>
+#import <WebRTC/RTCRtpReceiver.h>
+#import <WebRTC/RTCRtpTransceiver.h>
 
 #import "WebRTCModule.h"
 #import "WebRTCModule+RTCDataChannel.h"
 #import "WebRTCModule+RTCPeerConnection.h"
 #import "WebRTCModule+VideoTrackAdapter.h"
+#import "SerializeUtils.h"
 
 @implementation RTCPeerConnection (React)
 
@@ -81,6 +85,8 @@
 
 @implementation WebRTCModule (RTCPeerConnection)
 
+ int _transceiverNextId = 0;
+
 /*
  * This method is synchronous and blocking. This is done so we can implement createDataChannel
  * in the same way (synchronous) since the peer connection needs to exist before.
@@ -119,35 +125,6 @@ RCT_EXPORT_METHOD(peerConnectionSetConfiguration:(RTCConfiguration*)configuratio
   [peerConnection setConfiguration:configuration];
 }
 
-RCT_EXPORT_METHOD(peerConnectionAddStream:(nonnull NSString *)streamID objectID:(nonnull NSNumber *)objectID)
-{
-  RTCPeerConnection *peerConnection = self.peerConnections[objectID];
-  if (!peerConnection) {
-    return;
-  }
-  RTCMediaStream *stream = self.localStreams[streamID];
-  if (!stream) {
-    return;
-  }
-
-  [peerConnection addStream:stream];
-}
-
-RCT_EXPORT_METHOD(peerConnectionRemoveStream:(nonnull NSString *)streamID objectID:(nonnull NSNumber *)objectID)
-{
-  RTCPeerConnection *peerConnection = self.peerConnections[objectID];
-  if (!peerConnection) {
-    return;
-  }
-  RTCMediaStream *stream = self.localStreams[streamID];
-  if (!stream) {
-    return;
-  }
-
-  [peerConnection removeStream:stream];
-}
-
-
 RCT_EXPORT_METHOD(peerConnectionCreateOffer:(nonnull NSNumber *)objectID
                                     options:(NSDictionary *)options
                                    callback:(RCTResponseSenderBlock)callback)
@@ -174,16 +151,22 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer:(nonnull NSNumber *)objectID
           ]);
         } else {
           NSString *type = [RTCSessionDescription stringForType:sdp.type];
-          callback(@[@(YES), @{@"sdp": sdp.sdp, @"type": type}]);
+          callback(@[@(YES), @{
+                               @"sdpInfo": @{
+                                 @"sdp": sdp.sdp,
+                                 @"type": type
+                               },
+                               @"transceiversInfo": [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection peerConnectionId: objectID]
+          }]);
         }
       }];
 }
 
-RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSNumber *)peerConnectionId
+RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSNumber *)objectID
                                      options:(NSDictionary *)options
                                     callback:(RCTResponseSenderBlock)callback)
 {
-  RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+  RTCPeerConnection *peerConnection = self.peerConnections[objectID];
   if (!peerConnection) {
     return;
   }
@@ -205,7 +188,11 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSNumber *)peerConnectionI
            ]);
          } else {
            NSString *type = [RTCSessionDescription stringForType:sdp.type];
-           callback(@[@(YES), @{@"sdp": sdp.sdp, @"type": type}]);
+           callback(@[@(YES), @{
+                                @"sdpInfo": @{@"sdp": sdp.sdp,
+                                              @"type": type},
+                                @"transceiversInfo": [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection peerConnectionId: objectID]
+           }]);
          }
        }];
 }
@@ -229,8 +216,11 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(nonnull NSNumber *)objectID
       } else {
         RTCPeerConnection *strongPc = weakPc;
         id newSdp = @{
-            @"type": [RTCSessionDescription stringForType:strongPc.localDescription.type],
-            @"sdp": strongPc.localDescription.sdp
+
+            @"sdpInfo": @{@"type": [RTCSessionDescription stringForType:strongPc.localDescription.type],
+                          @"sdp": strongPc.localDescription.sdp
+            },
+            @"transceiversInfo": [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection peerConnectionId: objectID]
         };
         resolve(newSdp);
       }
@@ -251,19 +241,21 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(RTCSessionDescription *)sd
   }
 
   [peerConnection setRemoteDescription: sdp completionHandler: ^(NSError *error) {
-    if (error) {
-      id errorResponse = @{
-        @"name": @"SetRemoteDescriptionFailed",
-        @"message": error.localizedDescription ?: [NSNull null]
-      };
-      callback(@[@(NO), errorResponse]);
-    } else {
-      id newSdp = @{
-          @"type": [RTCSessionDescription stringForType:peerConnection.remoteDescription.type],
-          @"sdp": peerConnection.remoteDescription.sdp
-      };
-      callback(@[@(YES), newSdp]);
-    }
+      if (error) {
+        id errorResponse = @{
+          @"name": @"SetRemoteDescriptionFailed",
+          @"message": error.localizedDescription ?: [NSNull null]
+        };
+        callback(@[@(NO), errorResponse]);
+      } else {
+        id newSdp = @{
+            @"sdpInfo": @{
+                          @"type": [RTCSessionDescription stringForType:peerConnection.remoteDescription.type],
+                          @"sdp": peerConnection.remoteDescription.sdp},
+            @"transceiversInfo": [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection peerConnectionId: objectID]
+        };
+        callback(@[@(YES), newSdp]);
+      }
   }];
 }
 
@@ -302,10 +294,11 @@ RCT_EXPORT_METHOD(peerConnectionClose:(nonnull NSNumber *)objectID)
   }
 
   // Remove video track adapters
-  for(RTCMediaStream *stream in [peerConnection.remoteStreams allValues]) {
-    for (RTCVideoTrack *track in stream.videoTracks) {
-      [peerConnection removeVideoTrackAdapter:track];
-    }
+  for (NSString *key in peerConnection.remoteTracks.allKeys) {
+      RTCMediaStreamTrack *track = peerConnection.remoteTracks[key];
+      if (track.kind == kRTCMediaStreamTrackKindVideo) {
+        [peerConnection removeVideoTrackAdapter: (RTCVideoTrack*) track];
+      }
   }
 
   [peerConnection close];
@@ -351,6 +344,163 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
   [peerConnection restartIce];
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionAddTrack:(nonnull NSNumber *)objectID
+                                                      trackId:(NSString *)trackId
+                                                      options:(NSDictionary *)options)
+{
+   __block id params;
+
+    dispatch_sync(self.workerQueue, ^{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+        if (!peerConnection) {
+          RCTLogWarn(@"PeerConnection %@ not found in peerConnectionAddTrack()", objectID);
+          return;
+        }
+
+        RTCMediaStreamTrack *track = self.localTracks[trackId];
+
+        NSArray *streamIds = [options objectForKey:@"streamIds"];
+        RTCRtpSender *sender = [peerConnection addTrack: track streamIds: streamIds];
+        RTCRtpTransceiver *transceiver = nil;
+        
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+          if([t.sender.senderId isEqual: sender.senderId]) {
+            transceiver = t;
+            break;
+          }
+        }
+        
+        if (!transceiver) {
+            RCTLogWarn(@"Transceiver not found in peerConnectionAddTrack()");
+            return;
+        }
+        
+        params = @{
+            @"transceiverOrder": [NSNumber numberWithInt:_transceiverNextId++],
+            @"transceiver": [SerializeUtils transceiverToJSONWithPeerConnectionId: objectID transceiver: transceiver],
+            @"sender": [SerializeUtils senderToJSONWithPeerConnectionId: objectID sender: sender]
+        };
+    });
+
+    return params;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionAddTransceiver:(nonnull NSNumber *)objectID
+                                                            options:(NSDictionary *)options)
+{
+    __block id params;
+
+    dispatch_sync(self.workerQueue, ^{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+        if (!peerConnection) {
+          RCTLogWarn(@"PeerConnection %@ not found in peerConnectionAddTransceiver()", objectID);
+          return;
+        }
+
+        RTCRtpTransceiver *transceiver = nil;
+        NSString *kind = [options objectForKey:@"type"];
+        NSString *trackId = [options objectForKey:@"trackId"];
+        RTCRtpMediaType type = RTCRtpMediaTypeUnsupported;
+        
+        if (kind) {
+            if ([kind  isEqual: @"audio"]) {
+                type = RTCRtpMediaTypeAudio;
+            } else if ([kind  isEqual: @"video"]) {
+                type = RTCRtpMediaTypeVideo;
+            }
+            transceiver = [peerConnection addTransceiverOfType:type];
+        } else if (trackId) {
+            RTCMediaStreamTrack *track = self.localTracks[trackId];
+            
+            if(!track) {
+                track = peerConnection.remoteTracks[trackId];
+            }
+            
+            NSDictionary *initOptions = [options objectForKey:@"init"];
+            RTCRtpTransceiverInit *transceiverInit = [RTCRtpTransceiverInit new];
+           
+            if (initOptions) {
+                NSString *dirrection = [initOptions objectForKey:@"direction"];
+                if ([dirrection isEqual: @"sendrecv"]) {
+                    [transceiverInit setDirection:RTCRtpTransceiverDirectionSendRecv];
+                } else if ([dirrection isEqual: @"sendonly"]) {
+                     [transceiverInit setDirection:RTCRtpTransceiverDirectionSendOnly];
+                } else if ([dirrection isEqual: @"recvonly"]) {
+                     [transceiverInit setDirection:RTCRtpTransceiverDirectionRecvOnly];
+                } else if ([dirrection isEqual: @"inactive"]) {
+                     [transceiverInit setDirection:RTCRtpTransceiverDirectionInactive];
+                }
+                
+                NSArray *streamIds = [initOptions objectForKey:@"streamIds"];
+                if (streamIds) {
+                    [transceiverInit setStreamIds:streamIds];
+                }
+            }
+            
+            transceiver = [peerConnection addTransceiverWithTrack:track init:transceiverInit];
+        } else {
+            RCTLogWarn(@"peerConnectionAddTransceiver() no type nor trackId provided in options");
+            return;
+        }
+        
+        if (transceiver == nil) {
+            RCTLogWarn(@"peerConnectionAddTransceiver() Error adding transceiver");
+            return;
+        }
+        
+        params = @{
+           @"transceiverOrder": [NSNumber numberWithInt:_transceiverNextId++],
+           @"transceiver": [SerializeUtils transceiverToJSONWithPeerConnectionId: objectID transceiver: transceiver ]
+        };
+    });
+
+    return params;
+}
+
+RCT_EXPORT_METHOD(peerConnectionRemoveTrack:(nonnull NSNumber *)objectID
+                                   senderId:(nonnull NSString *)senderId)
+{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+        if (!peerConnection) {
+          RCTLogWarn(@"PeerConnection %@ not found in peerConnectionRemoveTrack()", objectID);
+          [self sendErrorWithEventName: kEventPeerConnectionOnError
+                              funcName: @"removeTrack"
+                               message: @"Peer Connection is not initialized"
+                                  info: nil];
+          return;
+        }
+        
+        RTCRtpTransceiver *transceiver = nil;
+        
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+            if (t.sender.senderId == senderId) {
+                transceiver = t;
+                break;
+            }
+        }
+        
+        if (!transceiver) {
+            RCTLogWarn(@"Transceiver not found in peerConnectionRemoveTrack()");
+            return;
+        }
+        
+        NSMutableDictionary *identifier = [NSMutableDictionary new];
+        identifier[@"peerConnectionId"] = objectID;
+        identifier[@"senderId"] = senderId;
+        
+        if ([peerConnection removeTrack: transceiver.sender]) {
+            [self sendEventWithName: kEventPeerConnectionOnRemoveTrackSuccessful
+                               body: identifier];
+        } else {
+            [self sendErrorWithEventName: kEventPeerConnectionOnError
+                                funcName: @"removeTrack"
+                                 message: @"Cannot remove track"
+                                    info: identifier];
+        }
+}
+
+// TODO: move these below to some SerializeUrils file
+
 /**
  * Constructs a JSON <tt>NSString</tt> representation of a specific
  * <tt>RTCStatisticsReport</tt>s.
@@ -362,14 +512,14 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
  */
 - (NSString *)statsToJSON:(RTCStatisticsReport *)report
 {
-  /* 
+  /*
   The initial capacity matters, of course, because it determines how many
   times the NSMutableString will have grow. But walking through the reports
   to compute an initial capacity which exactly matches the requirements of
   the reports is too much work without real-world bang here. An improvement
-  should be caching the required capacity from the previous invocation of the 
-  method and using it as the initial capacity in the next invocation. 
-  As I didn't want to go even through that,choosing just about any initial 
+  should be caching the required capacity from the previous invocation of the
+  method and using it as the initial capacity in the next invocation.
+  As I didn't want to go even through that,choosing just about any initial
   capacity is OK because NSMutableCopy doesn't have too bad a strategy of growing.
   */
   NSMutableString *s = [NSMutableString stringWithCapacity:16 * 1024];
@@ -390,7 +540,7 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
     RTCStatistics *statistics = report.statistics[key];
     [s appendString:@"\"timestamp\":"];
     [s appendFormat:@"%f", statistics.timestamp_us / 1000.0];
-    [s appendString:@",\"type\":\""]; 
+    [s appendString:@",\"type\":\""];
     [s appendString:statistics.type];
     [s appendString:@"\",\"id\":\""];
     [s appendString:statistics.id];
@@ -406,7 +556,7 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
     }
 
     [s appendString:@"}]"];
-  } 
+  }
 
   [s appendString:@"]"];
 
@@ -434,7 +584,7 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
         NSError *error;
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:statisticsValue
                                                            options:0
-                                                           error:&error];
+                                                            error:&error];
 
         if (!jsonData) {
             [s appendString:@"\""];
@@ -507,74 +657,6 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
                      body:@{
                        @"id": peerConnection.reactTag,
                        @"signalingState": [self stringForSignalingState:newState]
-                     }];
-}
-
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didAddStream:(RTCMediaStream *)stream {
-  NSString *streamReactTag = [[NSUUID UUID] UUIDString];
-  NSMutableArray *tracks = [NSMutableArray array];
-  for (RTCVideoTrack *track in stream.videoTracks) {
-    peerConnection.remoteTracks[track.trackId] = track;
-    [peerConnection addVideoTrackAdapter:track];
-    [tracks addObject:@{@"id": track.trackId, @"kind": track.kind, @"label": track.trackId, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
-  }
-  for (RTCAudioTrack *track in stream.audioTracks) {
-    peerConnection.remoteTracks[track.trackId] = track;
-    [tracks addObject:@{@"id": track.trackId, @"kind": track.kind, @"label": track.trackId, @"enabled": @(track.isEnabled), @"remote": @(YES), @"readyState": @"live"}];
-  }
-
-  peerConnection.remoteStreams[streamReactTag] = stream;
-
-  id newSdp = @{
-    @"type": [RTCSessionDescription stringForType:peerConnection.remoteDescription.type],
-    @"sdp": peerConnection.remoteDescription.sdp
-  };
-
-  [self sendEventWithName:kEventPeerConnectionAddedStream
-                     body:@{
-                       @"id": peerConnection.reactTag,
-                       @"streamId": stream.streamId,
-                       @"streamReactTag": streamReactTag,
-                       @"tracks": tracks,
-                       @"sdp": newSdp
-                     }];
-}
-
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didRemoveStream:(RTCMediaStream *)stream {
-  // XXX Find the stream by comparing the 'streamId' values. It turns out that WebRTC (as of M69) creates new wrapper
-  // instance for the native media stream before invoking the 'didRemoveStream' callback. This means it's a different
-  // RTCMediaStream instance passed to 'didAddStream' and 'didRemoveStream'.
-  NSString *streamReactTag = nil;
-  for (NSString *aReactTag in peerConnection.remoteStreams) {
-    RTCMediaStream *aStream = peerConnection.remoteStreams[aReactTag];
-    if ([aStream.streamId isEqualToString:stream.streamId]) {
-      streamReactTag = aReactTag;
-      break;
-    }
-  }
-  if (!streamReactTag) {
-    RCTLogWarn(@"didRemoveStream - stream not found, id: %@", stream.streamId);
-    return;
-  }
-  for (RTCVideoTrack *track in stream.videoTracks) {
-    [peerConnection removeVideoTrackAdapter:track];
-    [peerConnection.remoteTracks removeObjectForKey:track.trackId];
-  }
-  for (RTCAudioTrack *track in stream.audioTracks) {
-    [peerConnection.remoteTracks removeObjectForKey:track.trackId];
-  }
-  [peerConnection.remoteStreams removeObjectForKey:streamReactTag];
-
-  id newSdp = @{
-    @"type": [RTCSessionDescription stringForType:peerConnection.remoteDescription.type],
-    @"sdp": peerConnection.remoteDescription.sdp
-  };
-
-  [self sendEventWithName:kEventPeerConnectionRemovedStream
-                     body:@{
-                       @"id": peerConnection.reactTag,
-                       @"streamId": streamReactTag,
-                       @"sdp": newSdp
                      }];
 }
 
@@ -654,8 +736,82 @@ RCT_EXPORT_METHOD(peerConnectionRestartIce:(nonnull NSNumber *)objectID)
     [self sendEventWithName:kEventPeerConnectionDidOpenDataChannel body:body];
 }
 
+- (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection didAddReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)rtpReceiver
+               streams:(NSArray<RTC_OBJC_TYPE(RTCMediaStream) *> *)mediaStreams {
+    dispatch_async(self.workerQueue, ^{
+        RTCRtpTransceiver *transceiver = nil;
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+            if ([rtpReceiver.receiverId isEqual: t.receiver.receiverId]) {
+                transceiver = t;
+                break;
+            }
+        }
+        
+        if (!transceiver) {
+            RCTLogWarn(@"Transceiver not found in didAddReceiver()");
+            return;
+        }
+        
+        RTCMediaStreamTrack *track = rtpReceiver.track;
+        
+        if (peerConnection.remoteTracks[track.trackId]) {
+            return;
+        }
+        
+        if (track.kind == kRTCMediaStreamTrackKindVideo) {
+            RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+            [peerConnection addVideoTrackAdapter: videoTrack];
+        }
+        
+        peerConnection.remoteTracks[track.trackId] = track;
+        
+        NSMutableDictionary *params = [NSMutableDictionary new];
+        NSMutableArray *streams = [NSMutableArray new];
+        
+        for (RTCMediaStream * stream in mediaStreams) {
+            NSString *streamReactTag = nil;
+
+            for (NSString * key in [peerConnection.remoteStreams allKeys]) {
+                if ([[peerConnection.remoteStreams objectForKey:key] isEqual:stream]) {
+                    streamReactTag = key;
+                    break;
+                }
+            }
+            
+            if (!peerConnection.remoteStreams[stream.streamId]) {
+                peerConnection.remoteStreams[stream.streamId] = stream;
+            }
+            
+            if (!streamReactTag) {
+                NSUUID *uuid = [NSUUID UUID];
+                streamReactTag = [uuid UUIDString];
+                peerConnection.remoteStreams[streamReactTag] = stream;
+            }
+            
+            [streams addObject:[SerializeUtils streamToJSONWithPeerConnectionId:peerConnection.reactTag stream:stream streamReactTag:streamReactTag]];
+        }
+        
+        params[@"streams"] = streams;
+        params[@"receiver"] = [SerializeUtils receiverToJSONWithPeerConnectionId: peerConnection.reactTag receiver: rtpReceiver];
+        params[@"transceiverOrder"] = [NSNumber numberWithInt:_transceiverNextId++];
+        params[@"transceiver"] = [SerializeUtils transceiverToJSONWithPeerConnectionId: peerConnection.reactTag transceiver: transceiver];
+        params[@"id"] = peerConnection.reactTag;
+        
+        [self sendEventWithName: kEventPeerConnectionOnTrack
+                           body: params];
+    });
+}
+
 - (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didRemoveIceCandidates:(nonnull NSArray<RTCIceCandidate *> *)candidates {
-  // TODO
+    // Unimplemented, there is no matching web API.
+}
+
+- (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didAddStream:(nonnull RTCMediaStream *)stream {
+    // Unused in Unified Plan.
+}
+
+- (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didRemoveStream:(nonnull RTCMediaStream *)stream {
+    // Unused in Unified Plan.
 }
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+Transceivers.m
+++ b/ios/RCTWebRTC/WebRTCModule+Transceivers.m
@@ -1,0 +1,216 @@
+#import <objc/runtime.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
+
+#import <WebRTC/RTCRtpSender.h>
+#import <WebRTC/RTCRtpReceiver.h>
+
+#import "WebRTCModule.h"
+#import "SerializeUtils.h"
+
+@implementation WebRTCModule (Transceivers)
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(senderGetCapabilities)
+{
+    __block id params;
+
+    dispatch_sync(self.workerQueue, ^{
+        NSMutableArray *videoCodecs = [NSMutableArray new];
+        for(RTCVideoCodecInfo * videoCodecInfo in [self.encoderFactory supportedCodecs]) {
+            [videoCodecs addObject:@{
+                @"mimeType": [NSString stringWithFormat:@"video/%@", videoCodecInfo.name]
+            }];
+        }
+        
+        params = @{
+            @"codecs":videoCodecs
+        };
+    });
+
+    return params;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(receiverGetCapabilities)
+{
+    __block id params;
+
+    dispatch_sync(self.workerQueue, ^{
+        NSMutableArray *videoCodecs = [NSMutableArray new];
+        for(RTCVideoCodecInfo * videoCodecInfo in [self.decoderFactory supportedCodecs]) {
+            [videoCodecs addObject:@{
+                @"mimeType": [NSString stringWithFormat:@"video/%@", videoCodecInfo.name]
+            }];
+        }
+        
+        params = @{
+            @"codecs":videoCodecs
+        };
+    });
+
+    return params;
+}
+
+RCT_EXPORT_METHOD(senderReplaceTrack:(nonnull NSNumber *) objectID
+                            senderId:(NSString *)senderId
+                            trackId:(NSString *)trackId
+                            resolver:(RCTPromiseResolveBlock)resolve
+                            rejecter:(RCTPromiseRejectBlock)reject)
+{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+
+        if (peerConnection == nil) {
+            RCTLogWarn(@"PeerConnection %@ not found in senderReplaceTrack()", objectID);
+            reject(@"E_INVALID", @"Peer Connection is not initialized", nil);
+        }
+
+        RTCRtpTransceiver *transceiver = nil;
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+            if ([senderId isEqual: t.sender.senderId]) {
+                transceiver = t;
+                break;
+            }
+        }
+
+        if (transceiver == nil) {
+            RCTLogWarn(@"senderReplaceTrack() transceiver is null");
+            reject(@"E_INVALID", @"Could not get transceive", nil);
+        }
+        
+        RTCRtpSender *sender = transceiver.sender;
+        RTCMediaStreamTrack *track = self.localTracks[trackId];
+        [sender setTrack:track];
+        resolve(@true);
+}
+
+RCT_EXPORT_METHOD(senderSetParameters:(nonnull NSNumber *) objectID
+                            senderId:(NSString *)senderId
+                            options:(NSDictionary *)options
+                            resolver:(RCTPromiseResolveBlock)resolve
+                            rejecter:(RCTPromiseRejectBlock)reject)
+{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+
+        if (peerConnection == nil) {
+            RCTLogWarn(@"PeerConnection %@ not found in senderSetParameters()", objectID);
+            reject(@"E_INVALID", @"Peer Connection is not initialized", nil);
+        }
+
+        RTCRtpTransceiver *transceiver = nil;
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+            if ([senderId isEqual: t.sender.senderId]) {
+                transceiver = t;
+                break;
+            }
+        }
+
+        if (transceiver == nil) {
+            RCTLogWarn(@"senderSetParameters() transceiver is null");
+            reject(@"E_INVALID", @"Could not get transceive", nil);
+        }
+        
+        RTCRtpSender *sender = transceiver.sender;
+        RTCRtpParameters *parameters = sender.parameters;
+        [sender setParameters:[self updateParametersWithOptions: options params: parameters]];
+}
+
+RCT_EXPORT_METHOD(transceiverSetDirection:(nonnull NSNumber *) objectID
+                            senderId:(NSString *)senderId
+                            direction:(NSString *)direction)
+{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+
+        if (peerConnection == nil) {
+            RCTLogWarn(@"transceiverSetDirection() PeerConnection %@ not found in transceiverSetDirection()", objectID);
+            return;
+        }
+
+        RTCRtpTransceiver *transceiver = nil;
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+            if ([senderId isEqual: t.sender.senderId]) {
+                transceiver = t;
+                break;
+            }
+        }
+
+        if (transceiver == nil) {
+            RCTLogWarn(@"transceiverSetDirection() transceiver is null");
+            return;
+        }
+        
+        NSMutableDictionary *identifier = [NSMutableDictionary new];
+        identifier[@"peerConnectionId"] = objectID;
+        identifier[@"transceiverId"] = senderId;
+        
+        NSMutableDictionary *params = [NSMutableDictionary new];
+        RTCRtpTransceiverDirection oldDirrection = transceiver.direction;
+        params[@"oldDirection"] = [SerializeUtils serializeDirection: oldDirrection];
+        NSError *error;
+        [transceiver setDirection:[SerializeUtils parseDirection:direction] error: &error];
+        
+        if (error) {
+            [self sendErrorWithEventName: kEventTransceiverOnError
+                                funcName: @"transceiverSetDirection"
+                                 message: [error localizedDescription]
+                                    info: nil];
+        }
+}
+
+RCT_EXPORT_METHOD(transceiverStop:(nonnull NSNumber *) objectID
+                            senderId:(NSString *)senderId)
+{
+        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+
+        if (peerConnection == nil) {
+            RCTLogWarn(@"PeerConnection %@ not found in transceiverStop()", objectID);
+            return;
+        }
+
+        RTCRtpTransceiver *transceiver = nil;
+        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+            if ([senderId isEqual: t.sender.senderId]) {
+                transceiver = t;
+                break;
+            }
+        }
+
+        if (transceiver == nil) {
+            RCTLogWarn(@"senderSetParameters() transceiver is null");
+            return;
+        }
+
+        [transceiver stopInternal];
+        [self sendEventWithName:kEventTransceiverStopSuccessful
+                              body:@{
+                                @"peerConnectionId": objectID,
+                                @"transceiverId": senderId
+                              }];
+}
+
+- (RTCRtpParameters *) updateParametersWithOptions: (NSDictionary *) options
+                                        params: (RTCRtpParameters *) params{
+    NSArray *encodingsArray = options[@"encodings"];
+    NSArray *encodings = params.encodings;
+    
+    if ([encodingsArray count] != [encodings count]) {
+        return nil;
+    }
+    
+    for (int i = 0; i < [encodingsArray count]; i++) {
+        NSDictionary *encodingUpdate = encodingsArray[i];
+        RTCRtpEncodingParameters *encoding = encodings[i];
+        
+        [encoding setIsActive: encodingUpdate[@"active"]];
+        encoding.maxBitrateBps = encodingUpdate[@"maxBitrate"];
+        encoding.maxFramerate =  encodingUpdate[@"maxFramerate"];
+        encoding.scaleResolutionDownBy = encodingUpdate[@"scaleResolutionDownBy"];
+    }
+    
+    if ([options objectForKey:@"degradationPreference"]) {
+        params.degradationPreference = [options objectForKey:@"degradationPreference"];
+    }
+    
+    return params;
+}
+
+@end

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -17,13 +17,11 @@
 #import <WebRTC/RTCPeerConnection.h>
 #import <WebRTC/RTCAudioTrack.h>
 #import <WebRTC/RTCVideoTrack.h>
-#import <WebRTC/RTCVideoDecoderFactory.h>
-#import <WebRTC/RTCVideoEncoderFactory.h>
+#import <WebRTC/RTCDefaultVideoDecoderFactory.h>
+#import <WebRTC/RTCDefaultVideoEncoderFactory.h>
 
 static NSString *const kEventPeerConnectionSignalingStateChanged = @"peerConnectionSignalingStateChanged";
 static NSString *const kEventPeerConnectionStateChanged = @"peerConnectionStateChanged";
-static NSString *const kEventPeerConnectionAddedStream = @"peerConnectionAddedStream";
-static NSString *const kEventPeerConnectionRemovedStream = @"peerConnectionRemovedStream";
 static NSString *const kEventPeerConnectionOnRenegotiationNeeded = @"peerConnectionOnRenegotiationNeeded";
 static NSString *const kEventPeerConnectionIceConnectionChanged = @"peerConnectionIceConnectionChanged";
 static NSString *const kEventPeerConnectionIceGatheringChanged = @"peerConnectionIceGatheringChanged";
@@ -32,12 +30,20 @@ static NSString *const kEventPeerConnectionDidOpenDataChannel = @"peerConnection
 static NSString *const kEventDataChannelStateChanged = @"dataChannelStateChanged";
 static NSString *const kEventDataChannelReceiveMessage = @"dataChannelReceiveMessage";
 static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMuteChanged";
+static NSString *const kEventTransceiverStopSuccessful = @"transceiverStopSuccessful";
+static NSString *const kEventTransceiverOnError = @"transceiverOnError";
+static NSString *const kEventPeerConnectionOnRemoveTrack = @"peerConnectionOnRemoveTrack";
+static NSString *const kEventPeerConnectionOnRemoveTrackSuccessful = @"peerConnectionOnRemoveTrackSuccessful";
+static NSString *const kEventPeerConnectionOnTrack = @"peerConnectionOnTrack";
+static NSString *const kEventPeerConnectionOnError = @"peerConnectionOnError";
 
 @interface WebRTCModule : RCTEventEmitter <RCTBridgeModule>
 
 @property(nonatomic, strong) dispatch_queue_t workerQueue;
 
 @property (nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
+@property (nonatomic, strong) id<RTCVideoDecoderFactory> decoderFactory;
+@property (nonatomic, strong) id<RTCVideoEncoderFactory> encoderFactory;
 
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, RTCPeerConnection *> *peerConnections;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
@@ -47,5 +53,10 @@ static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMut
                         decoderFactory:(id<RTCVideoDecoderFactory>)decoderFactory;
 
 - (RTCMediaStream*)streamForReactTag:(NSString*)reactTag;
+
+- (void)sendErrorWithEventName: (NSString *) eventName
+                      funcName: (NSString *) funcName
+                       message: (NSString *) message
+                          info: (NSDictionary *) info;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -13,9 +13,6 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
 
-#import <WebRTC/RTCDefaultVideoDecoderFactory.h>
-#import <WebRTC/RTCDefaultVideoEncoderFactory.h>
-
 #import "WebRTCModule.h"
 #import "WebRTCModule+RTCPeerConnection.h"
 
@@ -62,6 +59,9 @@
     if (decoderFactory == nil) {
       decoderFactory = [[RTCDefaultVideoDecoderFactory alloc] init];
     }
+    _encoderFactory = encoderFactory;
+    _decoderFactory = decoderFactory;
+
     _peerConnectionFactory
       = [[RTCPeerConnectionFactory alloc] initWithEncoderFactory:encoderFactory
                                                   decoderFactory:decoderFactory];
@@ -94,6 +94,22 @@
   return stream;
 }
 
+- (void)sendErrorWithEventName: (NSString *) eventName
+                      funcName: (NSString *) funcName
+                       message: (NSString *) message
+                          info: (NSDictionary *) info {
+    NSMutableDictionary *errorInfo = [NSMutableDictionary new];
+    
+    errorInfo[@"func"] = funcName;
+    if (info)
+        errorInfo[@"info"] = info;
+    if (message)
+        errorInfo[@"message"] = message;
+
+    [self sendEventWithName: kEventPeerConnectionOnError
+                       body: errorInfo];
+}
+
 RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue
@@ -105,8 +121,6 @@ RCT_EXPORT_MODULE();
   return @[
     kEventPeerConnectionSignalingStateChanged,
     kEventPeerConnectionStateChanged,
-    kEventPeerConnectionAddedStream,
-    kEventPeerConnectionRemovedStream,
     kEventPeerConnectionOnRenegotiationNeeded,
     kEventPeerConnectionIceConnectionChanged,
     kEventPeerConnectionIceGatheringChanged,
@@ -114,7 +128,13 @@ RCT_EXPORT_MODULE();
     kEventPeerConnectionDidOpenDataChannel,
     kEventDataChannelStateChanged,
     kEventDataChannelReceiveMessage,
-    kEventMediaStreamTrackMuteChanged
+    kEventMediaStreamTrackMuteChanged,
+    kEventTransceiverStopSuccessful,
+    kEventTransceiverOnError,
+    kEventPeerConnectionOnRemoveTrack,
+    kEventPeerConnectionOnRemoveTrackSuccessful,
+    kEventPeerConnectionOnTrack,
+    kEventPeerConnectionOnError
   ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
       "dependencies": {
         "adm-zip": "0.5.9",
         "base64-js": "1.5.1",
+        "debug": "4.3.4",
         "event-target-shim": "6.0.2",
         "tar": "6.1.11"
       },
       "devDependencies": {
+        "@types/debug": "4.1.7",
         "@types/react": "17.0.40",
         "@types/react-native": "0.67.3",
         "husky": "7.0.2",
@@ -1853,6 +1855,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -2330,10 +2347,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3381,8 +3397,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/node-releases": {
       "version": "2.0.2",
@@ -5626,6 +5641,21 @@
         "fastq": "^1.6.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -5991,10 +6021,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -6763,8 +6792,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-releases": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "adm-zip": "0.5.9",
     "base64-js": "1.5.1",
+    "debug": "4.3.4",
     "event-target-shim": "6.0.2",
     "tar": "6.1.11"
   },
@@ -37,6 +38,7 @@
     "url": "https://github.com/react-native-webrtc/react-native-webrtc/issues"
   },
   "devDependencies": {
+    "@types/debug": "4.1.7",
     "@types/react": "17.0.40",
     "@types/react-native": "0.67.3",
     "husky": "7.0.2",

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -1,7 +1,27 @@
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
 
 const { WebRTCModule } = NativeModules;
 
 const EventEmitter = new NativeEventEmitter(WebRTCModule);
 
 export default EventEmitter;
+
+const _subscriptions: Map<any, EmitterSubscription[]> = new Map(); 
+
+type EventHandler = (event: any) => void;
+
+export function addListener(listener: any, eventName: string, eventHandler: EventHandler): void {
+    if (!_subscriptions.has(listener)) {
+        _subscriptions.set(listener, []);
+    }
+
+    _subscriptions.get(listener)?.push(EventEmitter.addListener(eventName, eventHandler));
+}
+
+export function removeListener(listener: any): void {
+    _subscriptions.get(listener)?.forEach(sub => {
+        sub.remove();
+    });
+
+    _subscriptions.delete(listener);
+}

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,0 +1,49 @@
+import debug from 'debug';
+
+
+export default class Logger {
+    static ROOT_PREFIX = 'rn-webrtc';
+ 
+    private _debug: debug.Debugger;
+    private _info: debug.Debugger;
+    private _warn: debug.Debugger;
+    private _error: debug.Debugger;
+
+    static enable(ns: string): void {
+        debug.enable(ns);
+    }
+
+    constructor(prefix: string) {
+        const _prefix = `${Logger.ROOT_PREFIX}:${prefix}`;
+
+        this._debug = debug(`${_prefix}:DEBUG`);
+        this._info = debug(`${_prefix}:INFO`);
+        this._warn = debug(`${_prefix}:WARN`);
+        this._error = debug(`${_prefix}:ERROR`);
+
+        const log = console.log.bind(console);
+
+        this._debug.log = log;
+        this._info.log = log;
+        this._warn.log = log;
+        this._error.log = log;
+    }
+
+    debug(msg: string): void {
+        this._debug(msg);
+    }
+
+    info(msg: string): void {
+        this._info(msg);
+    }
+
+    warn(msg: string): void {
+        this._warn(msg);
+    }
+
+    error(msg: string, err?: Error): void {
+        const trace = err?.stack ?? 'N/A';
+
+        this._error(`${msg} Trace: ${trace}`);
+    }
+}

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -15,13 +15,14 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
     _enabled: boolean;
     _settings: object;
     _muted: boolean;
+    _peerConnectionId: number;
 
-    id: string;
-    kind: string;
-    label: string;
+    readonly id: string;
+    readonly kind: string;
+    readonly label: string = "";
     readyState: MediaStreamTrackState;
-    remote: boolean;
-
+    readonly remote: boolean;
+    
     constructor(info) {
         super();
 
@@ -29,10 +30,10 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         this._enabled = info.enabled;
         this._settings = info.settings || {};
         this._muted = false;
+        this._peerConnectionId = info.peerConnectionId;
 
         this.id = info.id;
         this.kind = info.kind;
-        this.label = info.label;
         this.remote = info.remote;
 
         const _readyState = info.readyState.toLowerCase();
@@ -97,7 +98,7 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
     getSettings() {
         return deepClone(this._settings);
     }
-
+    
     release(): void {
         WebRTCModule.mediaStreamTrackRelease(this.id);
     }

--- a/src/RTCErrorEvent.ts
+++ b/src/RTCErrorEvent.ts
@@ -1,0 +1,21 @@
+import RTCEvent from "./RTCEvent";
+
+type RTCPeerConnectionErrorFunc =
+    | 'addTransceiver'
+    | 'getTransceivers'
+    | 'addTrack'
+    | 'removeTrack';
+
+/**
+ * @brief This class Represents internal error happening on the native side as
+ * part of asynchronous invocations to synchronous web APIs. 
+ */
+export default class RTCErrorEvent extends RTCEvent {
+  readonly func: RTCPeerConnectionErrorFunc;
+  readonly message: string;
+  constructor(type: string, func: RTCPeerConnectionErrorFunc, message: string) {
+    super(type);
+    this.func = func;
+    this.message = message;
+  }
+}

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -1,19 +1,26 @@
 
-import { defineCustomEventTarget } from 'event-target-shim';
+import { defineCustomEventTarget, Event } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
+import Logger from './Logger';
 import MediaStream from './MediaStream';
-import MediaStreamEvent from './MediaStreamEvent';
-import MediaStreamTrackEvent from './MediaStreamTrackEvent';
+import MediaStreamTrack from './MediaStreamTrack';
+import RTCRtpTransceiver from './RTCRtpTransceiver';
 import RTCDataChannel from './RTCDataChannel';
 import RTCDataChannelEvent from './RTCDataChannelEvent';
+import RTCTrackEvent from './RTCTrackEvent';
 import RTCSessionDescription from './RTCSessionDescription';
 import RTCIceCandidate from './RTCIceCandidate';
 import RTCIceCandidateEvent from './RTCIceCandidateEvent';
+import RTCErrorEvent from './RTCErrorEvent';
 import RTCEvent from './RTCEvent';
 import * as RTCUtil from './RTCUtil';
-import EventEmitter from './EventEmitter';
+import EventEmitter, { addListener, removeListener } from './EventEmitter';
+import RTCRtpReceiver from './RTCRtpReceiver';
+import RTCRtpSender from './RTCRtpSender';
+import RTCRtpSendParameters from './RTCRtpSendParameters';
 
+const log = new Logger('pc');
 const { WebRTCModule } = NativeModules;
 
 type RTCSignalingState =
@@ -48,8 +55,8 @@ const PEER_CONNECTION_EVENTS = [
     'negotiationneeded',
     'signalingstatechange',
     'datachannel',
-    'addstream',
-    'removestream'
+    'track',
+    'error'
 ];
 
 let nextPeerConnectionId = 0;
@@ -64,60 +71,58 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
     iceConnectionState: RTCIceConnectionState = 'new';
 
     _peerConnectionId: number;
-    _localStreams: MediaStream[] = [];
-    _remoteStreams: MediaStream[] = [];
     _subscriptions: any[] = [];
+    _transceivers: { order: number, transceiver: RTCRtpTransceiver }[] = [];
+    _remoteStreams: Map<string, MediaStream> = new Map<string, MediaStream>();
 
     constructor(configuration) {
         super();
         this._peerConnectionId = nextPeerConnectionId++;
         WebRTCModule.peerConnectionInit(configuration, this._peerConnectionId);
         this._registerEvents();
-    }
 
-    addStream(stream: MediaStream): void {
-        const index = this._localStreams.indexOf(stream);
-        if (index !== -1) {
-            return;
-        }
-        WebRTCModule.peerConnectionAddStream(stream._reactTag, this._peerConnectionId);
-        this._localStreams.push(stream);
-    }
-
-    removeStream(stream: MediaStream): void {
-        const index = this._localStreams.indexOf(stream);
-        if (index === -1) {
-            return;
-        }
-        this._localStreams.splice(index, 1);
-        WebRTCModule.peerConnectionRemoveStream(stream._reactTag, this._peerConnectionId);
+        log.debug(`${this._peerConnectionId} ctor`);
     }
 
     createOffer(options) {
+        log.debug(`${this._peerConnectionId} createOffer`);
+
         return new Promise((resolve, reject) => {
             WebRTCModule.peerConnectionCreateOffer(
                 this._peerConnectionId,
-                RTCUtil.normalizeOfferAnswerOptions(options),
+                RTCUtil.normalizeOfferOptions(options),
                 (successful, data) => {
                     if (successful) {
-                        resolve(data);
+                        log.debug(`${this._peerConnectionId} createOffer OK`);
+
+                        this._updateTransceivers(data.transceiversInfo);
+                        resolve(data.sdpInfo);
                     } else {
-                        reject(data); // TODO: convert to NavigatorUserMediaError
+                        log.debug(`${this._peerConnectionId} createOffer ERROR`);
+
+                        reject(data);
                     }
                 }
             );
         });
     }
 
-    createAnswer(options = {}) {
+    createAnswer() {
+        log.debug(`${this._peerConnectionId} createAnswer`);
+
         return new Promise((resolve, reject) => {
             WebRTCModule.peerConnectionCreateAnswer(
                 this._peerConnectionId,
-                RTCUtil.normalizeOfferAnswerOptions(options),
+                {},
                 (successful, data) => {
                     if (successful) {
-                        resolve(data);
+                        log.debug(`${this._peerConnectionId} createAnswer OK`);
+
+                        this._updateTransceivers(data.transceiversInfo);
+                        resolve(data.sdpInfo);
                     } else {
+                        log.debug(`${this._peerConnectionId} createAnswer ERROR`);
+
                         reject(data);
                     }
                 }
@@ -130,24 +135,34 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
     }
 
     async setLocalDescription(sessionDescription?: RTCSessionDescription): Promise<void> {
+        log.debug(`${this._peerConnectionId} setLocalDescription`);
+
         const desc = sessionDescription
             ? sessionDescription.toJSON
                 ? sessionDescription.toJSON()
                 : sessionDescription
             : null;
-        const newSdp = await WebRTCModule.peerConnectionSetLocalDescription(this._peerConnectionId, desc);
+        const { sdpInfo, transceiversInfo } = await WebRTCModule.peerConnectionSetLocalDescription(this._peerConnectionId, desc);
 
-        this.localDescription = new RTCSessionDescription(newSdp);
+        this.localDescription = new RTCSessionDescription(sdpInfo);
+        this._updateTransceivers(transceiversInfo);
+
+        log.debug(`${this._peerConnectionId} setLocalDescription OK`);
     }
 
     setRemoteDescription(sessionDescription: RTCSessionDescription): Promise<void> {
+        log.debug(`${this._peerConnectionId} setRemoteDescription`);
+
         return new Promise((resolve, reject) => {
             WebRTCModule.peerConnectionSetRemoteDescription(
                 sessionDescription.toJSON ? sessionDescription.toJSON() : sessionDescription,
                 this._peerConnectionId,
                 (successful, data) => {
                     if (successful) {
-                        this.remoteDescription = new RTCSessionDescription(data);
+                        log.debug(`${this._peerConnectionId} setRemoteDescription OK`);
+
+                        this.remoteDescription = new RTCSessionDescription(data.sdpInfo);
+                        this._updateTransceivers(data.transceiversInfo);
                         resolve();
                     } else {
                         reject(data);
@@ -158,6 +173,8 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
     }
 
     async addIceCandidate(candidate): Promise<void> {
+        log.debug(`${this._peerConnectionId} addIceCandidate`);
+
         if (!candidate || !candidate.candidate) {
             // XXX end-of cantidates is not implemented: https://bugs.chromium.org/p/webrtc/issues/detail?id=9218
             return;
@@ -171,7 +188,113 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         this.remoteDescription = new RTCSessionDescription(newSdp);
     }
 
+    /**
+     * @brief Adds a new track to the {@link RTCPeerConnection}, 
+     * and indicates that it is contained in the specified {@link MediaStream} array.
+     * This method has to be synchronous as the W3C API expects a track to be return
+     * @param {MediaStreamTrack} track The track to be added
+     * @param {MediaStream[]} streams An array of streams the track needs to be added to
+     * https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtrack
+     */
+    addTrack(track: MediaStreamTrack, streams: MediaStream[] = []): RTCRtpSender {
+        log.debug(`${this._peerConnectionId} addTrack`);
+
+        if (this.connectionState === 'closed') throw new Error("Peer Connection is closed");
+        if (this._trackExists(track)) throw new Error("Track already exists in a sender");
+
+        const streamIds = streams.map((s) => s.id);
+        const result = WebRTCModule.peerConnectionAddTrack(this._peerConnectionId, track.id, { streamIds });
+        if (result == null) throw new Error("Could not add sender");
+        const { transceiverOrder, transceiver, sender } = result;
+
+        // According to the W3C docs, the sender could have been reused, and 
+        // so we check if that is the case, and update accordingly.
+        const [existingSender] = this
+            .getSenders()
+            .filter((s) => s.id === sender.id);
+        
+        if (existingSender) {
+            // Update sender
+            existingSender._track = track;
+
+            // Update the corresponding transceiver as well
+            const [existingTransceiver] = this
+                .getTransceivers()
+                .filter((t) => t.sender.id === existingSender.id);
+            existingTransceiver._direction = transceiver.direction;
+            existingTransceiver._currentDirection = transceiver.currentDirection;
+            return existingSender;
+        }
+
+        // This is a new transceiver, should create a transceiver for it and add it
+        const newSender = new RTCRtpSender({ ...transceiver.sender, track });
+        const newTransceiver = new RTCRtpTransceiver({
+            ...transceiver,
+            sender: newSender,
+            receiver: new RTCRtpReceiver(transceiver.receiver),
+        });
+
+        this._insertTransceiverSorted(transceiverOrder, newTransceiver);
+
+        return newSender;
+    }
+
+    addTransceiver(source: 'audio' | 'video' | MediaStreamTrack, init): RTCRtpTransceiver {
+        log.debug(`${this._peerConnectionId} addTransceiver`);
+
+        let src = {};
+        if (source === 'audio') {
+            src = { type: 'audio' };
+        } else if (source === 'video') {
+            src = { type: 'video' };
+        } else {
+            src = { trackId: source.id };
+        }
+        // Extract the stream ids 
+        if (init && init.streams) {
+            init.streamIds = init.streams.map((stream) => {
+                return stream.id;
+            });
+        }
+
+        const result = WebRTCModule.peerConnectionAddTransceiver(this._peerConnectionId, { ...src, init: { ...init } });
+        if (result == null) {
+            console.log("Error adding transceiver");
+            throw new Error("Transceiver could not be added");
+        }
+        const sender = new RTCRtpSender(result.transceiver.sender);
+        if (source instanceof MediaStreamTrack) {
+            sender._track = source;
+        }
+        const receiver = new RTCRtpReceiver(result.transceiver.receiver);
+        const transceiver = new RTCRtpTransceiver({
+            ...result.transceiver,
+            sender,
+            receiver
+        });
+        this._insertTransceiverSorted(result.transceiverOrder, transceiver);
+        return transceiver;
+    }
+
+    removeTrack(sender: RTCRtpSender) {
+        log.debug(`${this._peerConnectionId} removeTrack`);
+
+        if (this._peerConnectionId !== sender._peerConnectionId)
+            throw new Error("Sender does not belong to this peer connection");
+        if (this.connectionState === 'closed') throw new Error("Peer Connection is closed");
+        
+        const existingSender = this
+            .getSenders()
+            .find((s) => s === sender);
+        if (!existingSender) throw new Error("Sender does not exist");
+        if (existingSender.track === null) return;
+
+        WebRTCModule.peerConnectionRemoveTrack(this._peerConnectionId, sender.id);
+    }
+
     getStats() {
+        log.debug(`${this._peerConnectionId} getStats`);
+
         return WebRTCModule.peerConnectionGetStats(this._peerConnectionId).then(data => {
             /* On both Android and iOS it is faster to construct a single
             JSON string representing the Map of StatsReports and have it
@@ -188,15 +311,26 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         });
     }
 
-    getLocalStreams(): MediaStream[] {
-        return this._localStreams.slice();
+    getTransceivers(): RTCRtpTransceiver[] {
+        return this._transceivers.map(e => e.transceiver);
     }
 
-    getRemoteStreams(): MediaStream[] {
-        return this._remoteStreams.slice();
+    getSenders(): RTCRtpSender[] {
+        return this._transceivers.map(e => e.transceiver.sender);
+    }
+
+    getReceivers(): RTCRtpReceiver[] {
+        return this._transceivers.map(e => e.transceiver.receiver);
     }
 
     close(): void {
+        log.debug(`${this._peerConnectionId} close`);
+
+        // According to the W3C spec: https://w3c.github.io/webrtc-pc/#rtcpeerconnection-interface
+        // transceivers have to be stopped
+        this._transceivers.forEach(({ transceiver })=> {
+            transceiver.stop();
+        })
         WebRTCModule.peerConnectionClose(this._peerConnectionId);
     }
 
@@ -204,128 +338,195 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         WebRTCModule.peerConnectionRestartIce(this._peerConnectionId);
     }
 
-    _unregisterEvents(): void {
-        this._subscriptions.forEach(e => e.remove());
-        this._subscriptions = [];
-    }
-
     _registerEvents(): void {
-        this._subscriptions = [
-            EventEmitter.addListener('peerConnectionOnRenegotiationNeeded', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
+        addListener(this, 'peerConnectionOnRenegotiationNeeded', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            // @ts-ignore
+            this.dispatchEvent(new RTCEvent('negotiationneeded'));
+        });
+        addListener(this, 'peerConnectionIceConnectionChanged', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            this.iceConnectionState = ev.iceConnectionState;
+            if (ev.iceConnectionState === 'closed') {
+                // This PeerConnection is done, clean up event handlers.
+                removeListener(this);
+            }
+            // @ts-ignore
+            this.dispatchEvent(new RTCEvent('iceconnectionstatechange'));
+        });
+        addListener(this, 'peerConnectionStateChanged', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            this.connectionState = ev.connectionState;
+            if (ev.connectionState === 'closed') {
+                // This PeerConnection is done, clean up event handlers.
+                removeListener(this);
+            }
+            // @ts-ignore
+            this.dispatchEvent(new RTCEvent('connectionstatechange'));
+        });
+        addListener(this, 'peerConnectionSignalingStateChanged', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            this.signalingState = ev.signalingState;
+            // @ts-ignore
+            this.dispatchEvent(new RTCEvent('signalingstatechange'));
+        })
+        addListener(this, 'peerConnectionOnTrack', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+
+            log.debug(`${this._peerConnectionId} ontrack`);
+
+            const track = new MediaStreamTrack(ev.receiver.track);
+            let transceiver;
+
+            // Make sure transceivers are stored in timestamp order. Also, we have to make
+            // sure we do not add a transceiver if it exists. 
+                // sure we do not add a transceiver if it exists. 
+            // sure we do not add a transceiver if it exists. 
+            let [{ transceiver: oldTransceiver } = { transceiver: null }] = this._transceivers.filter(({ transceiver }) => {
+                return transceiver.id === ev.transceiver.id;
+            });
+
+            if (!oldTransceiver) {
+                // Creating objects out of the event data.
+                const receiver = new RTCRtpReceiver({ ...ev.receiver, track });
+
+                transceiver = new RTCRtpTransceiver({ ...ev.transceiver, receiver });
+                this._insertTransceiverSorted(ev.transceiverOrder, transceiver);
+            } else {
+                transceiver = oldTransceiver;
+                transceiver._receiver._track = track;
+                transceiver._mid = ev.transceiver.mid;
+                transceiver._currentDirection = ev.transceiver.currentDirection;
+                transceiver._direction = ev.transceiver.direction;
+            }
+
+            // Get the stream object from the event. Create if necessary.
+            const streams = ev.streams.map(streamInfo => {
+                // Here we are making sure that we don't create stream objects that already exist
+                // So that event listeners do get the same object if it has been created before.
+                if (!this._remoteStreams.has(streamInfo.streamId)) {
+                    const stream = new MediaStream({
+                        streamId: streamInfo.streamId,
+                        streamReactTag: streamInfo.streamReactTag,
+                        tracks: []
+                    });
+                    this._remoteStreams.set(streamInfo.streamId, stream);
                 }
-                // @ts-ignore
-                this.dispatchEvent(new RTCEvent('negotiationneeded'));
-            }),
-            EventEmitter.addListener('peerConnectionIceConnectionChanged', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
+                const stream = this._remoteStreams.get(streamInfo.streamId);
+                stream?._tracks.push(track);
+                return stream;
+            });
+
+            const eventData = {
+                streams,
+                transceiver,
+                track,
+                receiver: transceiver.receiver
+            };
+
+            // @ts-ignore
+            this.dispatchEvent(new RTCTrackEvent('track', eventData));
+        });
+
+        addListener(this, 'peerConnectionOnRemoveTrack', ev => {
+            if (ev.peerConnectionId !== this._peerConnectionId) {
+                return;
+            }
+
+            log.debug(`${this._peerConnectionId} onremovetrack`);
+
+            // Based on the W3C specs https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-removetrack,
+            // we need to remove the track from any media streams
+            // that were previously passed to the `track` event. 
+            for (const stream of this._remoteStreams.values()) {
+                const trackIdx = stream._tracks.findIndex(t => t.id === ev.trackId);
+                if (trackIdx !== -1) {
+                    stream._tracks.splice(trackIdx, 1);
                 }
-                this.iceConnectionState = ev.iceConnectionState;
-                // @ts-ignore
-                this.dispatchEvent(new RTCEvent('iceconnectionstatechange'));
-                if (ev.iceConnectionState === 'closed') {
-                    // This PeerConnection is done, clean up event handlers.
-                    this._unregisterEvents();
-                }
-            }),
-            EventEmitter.addListener('peerConnectionStateChanged', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
-                this.connectionState = ev.connectionState;
-                // @ts-ignore
-                this.dispatchEvent(new RTCEvent('connectionstatechange'));
-                if (ev.connectionState === 'closed') {
-                    // This PeerConnection is done, clean up event handlers.
-                    this._unregisterEvents();
-                }
-            }),
-            EventEmitter.addListener('peerConnectionSignalingStateChanged', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
-                this.signalingState = ev.signalingState;
-                // @ts-ignore
-                this.dispatchEvent(new RTCEvent('signalingstatechange'));
-            }),
-            EventEmitter.addListener('peerConnectionAddedStream', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
-                const stream = new MediaStream(ev);
-                this._remoteStreams.push(stream);
-                this.remoteDescription = new RTCSessionDescription(ev.sdp);
-                // @ts-ignore
-                this.dispatchEvent(new MediaStreamEvent('addstream', { stream }));
-            }),
-            EventEmitter.addListener('peerConnectionRemovedStream', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
-                const stream = this._remoteStreams.find(s => s._reactTag === ev.streamId);
-                if (stream) {
-                    const index = this._remoteStreams.indexOf(stream);
-                    if (index !== -1) {
-                        this._remoteStreams.splice(index, 1);
-                    }
-                }
-                this.remoteDescription = new RTCSessionDescription(ev.sdp);
-                // @ts-ignore
-                this.dispatchEvent(new MediaStreamEvent('removestream', { stream }));
-            }),
-            EventEmitter.addListener('mediaStreamTrackMuteChanged', ev => {
-                if (ev.peerConnectionId !== this._peerConnectionId) {
-                    return;
-                }
-                let track;
-                for (const stream of this._remoteStreams) {
-                    const t = stream._tracks.find(track => track.id === ev.trackId);
-                    if (t) {
-                        track = t;
-                        break;
-                    }
-                }
-                if (track) {
-                    track._muted = ev.muted;
-                    const eventName = ev.muted ? 'mute' : 'unmute';
-                    track.dispatchEvent(new MediaStreamTrackEvent(eventName, { track }));
-                }
-            }),
-            EventEmitter.addListener('peerConnectionGotICECandidate', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
+            }
+        });
+
+        addListener(this, 'peerConnectionOnRemoveTrackSuccessful', ev => {
+            if (ev.peerConnectionId !== this._peerConnectionId) {
+                return;
+            }
+            const [existingSender] = this
+                .getSenders()
+                .filter((s) => s.id === ev.senderId);
+
+            const oldTrack = existingSender._track;
+
+            if (oldTrack) {
+                oldTrack._muted = true;
+            }
+
+            existingSender._track = null;
+
+            const [existingTransceiver] = this
+                .getTransceivers()
+                .filter((t) => t.sender.id === existingSender.id);
+            existingTransceiver._direction = existingTransceiver.direction === 'sendrecv' ? 'recvonly' : 'inactive';
+        });
+
+        addListener(this, 'peerConnectionGotICECandidate', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            this.localDescription = new RTCSessionDescription(ev.sdp);
+            const candidate = new RTCIceCandidate(ev.candidate);
+            // @ts-ignore
+            this.dispatchEvent(new RTCIceCandidateEvent('icecandidate', { candidate }));
+        });
+
+        addListener(this, 'peerConnectionIceGatheringChanged', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            this.iceGatheringState = ev.iceGatheringState;
+
+            if (this.iceGatheringState === 'complete') {
                 this.localDescription = new RTCSessionDescription(ev.sdp);
-                const candidate = new RTCIceCandidate(ev.candidate);
                 // @ts-ignore
-                this.dispatchEvent(new RTCIceCandidateEvent('icecandidate', { candidate }));
-            }),
-            EventEmitter.addListener('peerConnectionIceGatheringChanged', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
-                this.iceGatheringState = ev.iceGatheringState;
+                this.dispatchEvent(new RTCIceCandidateEvent('icecandidate', { candidate: null }));
+            }
 
-                if (this.iceGatheringState === 'complete') {
-                    this.localDescription = new RTCSessionDescription(ev.sdp);
-                    // @ts-ignore
-                    this.dispatchEvent(new RTCIceCandidateEvent('icecandidate', { candidate: null }));
-                }
+            // @ts-ignore
+            this.dispatchEvent(new RTCEvent('icegatheringstatechange'));
+        });
 
-                // @ts-ignore
-                this.dispatchEvent(new RTCEvent('icegatheringstatechange'));
-            }),
-            EventEmitter.addListener('peerConnectionDidOpenDataChannel', ev => {
-                if (ev.id !== this._peerConnectionId) {
-                    return;
-                }
-                const channel = new RTCDataChannel(ev.dataChannel);
-                // @ts-ignore
-                this.dispatchEvent(new RTCDataChannelEvent('datachannel', { channel }));
-            })
-        ];
+        addListener(this, 'peerConnectionDidOpenDataChannel', ev => {
+            if (ev.id !== this._peerConnectionId) {
+                return;
+            }
+            const channel = new RTCDataChannel(ev.dataChannel);
+            // @ts-ignore
+            this.dispatchEvent(new RTCDataChannelEvent('datachannel', { channel }));
+        });
+
+        // Since the current underlying architecture performs certain actions
+        // Asynchronously when the outer web API expects synchronous behaviour
+        // This is the only way to report error on operations for those who wish
+        // to handle them.
+        addListener(this, 'peerConnectionOnError', ev => {
+            if (ev.info.peerConnectionId !== this._peerConnectionId) {
+                return;
+            }
+            
+            log.error(`onerror: ${JSON.stringify(ev)}`);
+
+            // @ts-ignore
+            this.dispatchEvent(new RTCErrorEvent('error', ev.func, ev.message));
+        });
     }
 
     /**
@@ -354,5 +555,46 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         }
 
         return new RTCDataChannel(channelInfo);
+    }
+    
+    /**
+     * Check whether a media stream track exists already in a sender. 
+     * See https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtrack for more information
+     */
+    _trackExists(track: MediaStreamTrack): boolean {
+        const [sender] = this
+            .getSenders()
+            .filter(
+                (sender) => sender.track?.id === track.id
+            )
+        return sender? true : false;
+    }
+
+    /**
+     * updates transceivers after offer/answer updates if necessary
+     */
+    _updateTransceivers(transceiverUpdates) {
+        for (var update of transceiverUpdates) {
+            const [transceiver] = this
+                .getTransceivers()
+                .filter((t) => t.id === update.transceiverId);
+            
+            if (!transceiver) continue;
+            transceiver._currentDirection = update.currentDirection;
+            transceiver._mid = update.mid;
+            transceiver._sender._rtpParameters = new RTCRtpSendParameters(update.senderRtpParameters);
+        }
+    }
+
+    /**
+     * Inserts transceiver into the transceiver array in the order they are created (timestamp).
+     * @param order an index that refers to when it it was created relatively.
+     * @param transceiver the transceiver object to be inserted.
+     */
+    _insertTransceiverSorted(order: number, transceiver: RTCRtpTransceiver) {
+        this._transceivers.push({ order, transceiver });
+        this._transceivers.sort((a, b) => {
+            return a.order - b.order;
+        })
     }
 }

--- a/src/RTCRtcpParameters.ts
+++ b/src/RTCRtcpParameters.ts
@@ -1,0 +1,14 @@
+
+export default class RTCRtcpParameters {
+  readonly cname: string;
+  readonly reducedSize: boolean;
+
+  constructor(init: {
+    cname: string,
+    reducedSize: boolean
+  }) {
+    this.cname = init.cname;
+    this.reducedSize = init.reducedSize;
+    Object.freeze(this);
+  }
+}

--- a/src/RTCRtpCapabilities.ts
+++ b/src/RTCRtpCapabilities.ts
@@ -1,0 +1,54 @@
+import {NativeModules} from 'react-native';
+import RTCRtpCodecCapability from './RTCRtpCodecCapability';
+const { WebRTCModule } = NativeModules;
+
+/**
+ * @brief represents codec capabilities for senders and receivers. Currently
+ * this only supports codec names and does not have other
+ * fields like clockRate and numChannels and such.
+ */
+export default class RTCRtpCapabilities {
+    _codecs: RTCRtpCodecCapability[] = [];
+    constructor(codecs: RTCRtpCodecCapability[]) {
+        this._codecs = codecs;
+        Object.freeze(this);
+    }
+    
+    get codecs() {
+        return this._codecs;
+    }
+}
+
+
+function getCapabilities(endpoint: 'sender' | 'receiver'): RTCRtpCapabilities | null {
+    switch (endpoint) {
+        case 'sender': {
+            const capabilities = WebRTCModule.senderGetCapabilities();
+            if (!capabilities) return null;
+            return new RTCRtpCapabilities(capabilities.codecs);
+        }
+        case 'receiver': {
+            const capabilities = WebRTCModule.receiverGetCapabilities();
+            if (!capabilities) return null;
+            return new RTCRtpCapabilities(capabilities.codecs);
+        }
+        default:
+            throw new TypeError('Invalid endpoint: ' + endpoint);
+    }
+}
+
+
+/**
+ * Hardcoded audio capabilities based on the WebRTC native documentation:
+ * https://webrtc.github.io/webrtc-org/faq/. The mime type is specified in
+ * https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-2.
+ */
+export const DEFAULT_AUDIO_CAPABILITIES = new RTCRtpCapabilities([
+    new RTCRtpCodecCapability({ mimeType: 'audio/G722' }),
+    new RTCRtpCodecCapability({ mimeType: 'audio/iLBC' }),
+]);
+
+// Initialize capabilities on module import
+export const senderCapabilities = getCapabilities('sender');
+export const receiverCapabilities = getCapabilities('receiver');
+

--- a/src/RTCRtpCodecCapability.ts
+++ b/src/RTCRtpCodecCapability.ts
@@ -1,0 +1,13 @@
+
+export default class RTCRtpCodecCapability {
+    _mimeType: string;
+
+    constructor(init: { mimeType: string }) {
+        this._mimeType = init.mimeType;
+        Object.freeze(this);
+    }
+
+    get mimeType() {
+        return this._mimeType;
+    }
+}

--- a/src/RTCRtpCodecParameters.ts
+++ b/src/RTCRtpCodecParameters.ts
@@ -1,0 +1,23 @@
+
+export default class RTCRtpCodecParameters {
+    readonly payloadType: number;
+    readonly clockRate: number;
+    readonly channels: number;
+    readonly mimeType: string;
+    readonly sdpFmtpLine: Map<String, String>;
+
+    constructor(init: {
+        payloadType: number,
+        clockRate: number,
+        channels: number,
+        mimeType: string,
+        sdpFmtpLine: Map<String, String>
+    }) {
+        this.payloadType = init.payloadType;
+        this.clockRate = init.clockRate;
+        this.channels = init.channels;
+        this.mimeType = init.mimeType;
+        this.sdpFmtpLine = init.sdpFmtpLine;
+        Object.freeze(this);
+    }
+}

--- a/src/RTCRtpEncodingParameters.ts
+++ b/src/RTCRtpEncodingParameters.ts
@@ -1,0 +1,67 @@
+
+export default class RTCRtpEncodingParameters {
+    readonly active: boolean;
+    _maxFramerate: number | null;
+    _maxBitrate: number | null;
+    _scaleResolutionDownBy: number | null;
+
+    constructor(init: {
+        active: boolean,
+        maxFramerate?: number;
+        maxBitrate?: number;
+        scaleResolutionDownBy?: number;
+    }) {
+        this.active = init.active;
+        this._maxBitrate = init.maxBitrate ?? null;
+        this._maxFramerate = init.maxFramerate ?? null;
+        this._scaleResolutionDownBy = init.scaleResolutionDownBy ?? null;
+    }
+
+    get maxFramerate() {
+        return this._maxFramerate;
+    }
+
+    get maxBitrate() {
+        return this._maxBitrate;
+    }
+
+    get scaleResolutionDownBy() {
+        return this._scaleResolutionDownBy;
+    }
+
+    set maxFramerate(framerate) {
+        if (framerate && framerate > 0) {
+            this._maxFramerate = framerate;
+        }
+    }
+    
+    set maxBitrate(bitrate) {
+        if (bitrate && bitrate > 0) {
+            this._maxBitrate = bitrate;
+        }
+    }
+    
+    set scaleResolutionDownBy(resolutionScale) {
+        if (resolutionScale && resolutionScale >= 1) {
+            this._scaleResolutionDownBy = resolutionScale;
+        }
+    }
+
+    toJSON() {
+        let obj = {
+            active: this.active,
+        }
+        if (this._maxBitrate !== null) {
+            obj['maxBitrate'] = this._maxBitrate;
+        } 
+
+        if (this._maxFramerate !== null) {
+            obj['maxFramerate'] = this._maxFramerate;
+        } 
+        
+        if (this._scaleResolutionDownBy !== null) {
+            obj['scaleResolutionDownBy'] = this._scaleResolutionDownBy;
+        } 
+        return obj;
+    }
+}   

--- a/src/RTCRtpHeaderExtension.ts
+++ b/src/RTCRtpHeaderExtension.ts
@@ -1,0 +1,18 @@
+
+export default class RTCRtpHeaderExtension {
+    readonly id: number;
+    readonly uri: string;
+    readonly encrypted: boolean;
+
+    constructor(init: {
+        id: number,
+        uri: string,
+        encrypted: boolean
+    }) {
+        this.id = init.id;
+        this.uri = init.uri;
+        this.encrypted = init.encrypted;
+        Object.freeze(this);
+    }
+}
+

--- a/src/RTCRtpParameters.ts
+++ b/src/RTCRtpParameters.ts
@@ -1,0 +1,21 @@
+import RTCRtcpParameters from "./RTCRtcpParameters";
+import RTCRtpCodecParameters from "./RTCRtpCodecParameters";
+import RTCRtpHeaderExtension from "./RTCRtpHeaderExtension";
+
+
+export type RTCRtpParametersInit = {
+    codecs: RTCRtpCodecParameters[],
+    headerExtensions: RTCRtpHeaderExtension[],
+    rtcp: RTCRtcpParameters
+}
+
+export default class RTCRtpParameters {
+    readonly codecs: RTCRtpCodecParameters[] = [];
+    readonly headerExtensions: RTCRtpHeaderExtension[] = [];
+    readonly rtcp: RTCRtcpParameters;
+    constructor(init: RTCRtpParametersInit) {
+        this.codecs = init.codecs;
+        this.headerExtensions = init.headerExtensions;
+        this.rtcp = init.rtcp;
+    }
+}

--- a/src/RTCRtpReceiveParameters.ts
+++ b/src/RTCRtpReceiveParameters.ts
@@ -1,0 +1,7 @@
+import RTCRtpParameters, { RTCRtpParametersInit } from "./RTCRtpParameters";
+export default class RTCRtpReceiveParameters extends RTCRtpParameters {
+
+    constructor(init: RTCRtpParametersInit) {
+        super(init);
+    }
+}

--- a/src/RTCRtpReceiver.ts
+++ b/src/RTCRtpReceiver.ts
@@ -1,0 +1,35 @@
+import { NativeModules } from 'react-native';
+import MediaStreamTrack from './MediaStreamTrack';
+import RTCRtpCapabilities, {DEFAULT_AUDIO_CAPABILITIES, receiverCapabilities } from './RTCRtpCapabilities';
+
+const { WebRTCModule } = NativeModules;
+
+export default class RTCRtpReceiver {
+    _id: string;
+    _peerConnectionId: number;
+    _track: MediaStreamTrack;
+
+    constructor(info: { peerConnectionId: number, id: string, track: MediaStreamTrack }) {
+        this._id = info.id;
+        this._peerConnectionId = info.peerConnectionId;
+        this._track = info.track;
+    }
+
+    static getCapabilities(kind: "audio" | "video"): RTCRtpCapabilities {
+        if (kind == "audio") {
+          return DEFAULT_AUDIO_CAPABILITIES;    
+        }
+
+        if (!receiverCapabilities)
+            throw new Error('Receiver Capabilities is null');
+        return receiverCapabilities;
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    get track() {
+        return this._track;
+    }
+}

--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -1,0 +1,51 @@
+import RTCRtpParameters, { RTCRtpParametersInit } from "./RTCRtpParameters";
+import RTCRtpEncodingParameters from "./RTCRtpEncodingParameters";
+
+type DegradationPreferenceType = 'maintain-framerate' 
+    | 'maintain-resolution'
+    | 'balanced'
+    | 'disabled'
+
+
+/**
+ * Class to convert degradation preference format. Native has a format such as
+ * MAINTAIN_FRAMERATE whereas the web APIs expect maintain-framerate
+ */
+class DegradationPreference {
+    static fromNative(nativeFormat: string): DegradationPreferenceType {
+        const stringFormat = nativeFormat.toLowerCase().replace('_', '-');
+        return stringFormat as DegradationPreferenceType;
+    }
+
+    static toNative(format: DegradationPreferenceType): string {
+        return format.toUpperCase().replace('-', '_');
+    }
+} 
+
+export default class RTCRtpSendParameters extends RTCRtpParameters {
+
+    readonly transactionId: string;
+    readonly encodings: RTCRtpEncodingParameters[];
+    degradationPreference: DegradationPreferenceType | null;
+    constructor(init: RTCRtpParametersInit & {
+        transactionId: string,
+        encodings: RTCRtpEncodingParameters[],
+        degradationPreference?: string
+    }) {
+        super(init);
+        this.transactionId = init.transactionId;
+        this.encodings = init.encodings;
+        this.degradationPreference = init.degradationPreference ?
+            DegradationPreference.fromNative(init.degradationPreference) : null;
+    }
+
+    toJSON() {
+        let obj = {
+            encodings: this.encodings,
+        };
+        if (this.degradationPreference !== null) {
+            obj['degradationPreference'] = DegradationPreference.toNative(this.degradationPreference);
+        }
+        return obj
+    }
+}

--- a/src/RTCRtpSender.ts
+++ b/src/RTCRtpSender.ts
@@ -1,0 +1,72 @@
+import {NativeModules} from 'react-native';
+import MediaStreamTrack from './MediaStreamTrack';
+import RTCRtpCapabilities, { senderCapabilities, DEFAULT_AUDIO_CAPABILITIES } from './RTCRtpCapabilities';
+import RTCRtpSendParameters from './RTCRtpSendParameters';
+
+const {WebRTCModule} = NativeModules;
+
+
+export default class RTCRtpSender {
+    _id: string;
+    _track: MediaStreamTrack | null = null;
+    _peerConnectionId: number;
+    _rtpParameters: RTCRtpSendParameters;
+
+    constructor(info: {
+        peerConnectionId: number,
+        id: string,
+        track?: MediaStreamTrack,
+        rtpParameters: RTCRtpSendParameters
+    }) {
+        this._peerConnectionId = info.peerConnectionId;
+        this._id = info.id;
+        this._rtpParameters = info.rtpParameters;
+
+        if (info.track) {
+            this._track = info.track;
+        }
+    }
+
+    async replaceTrack(track: MediaStreamTrack | null): Promise<void> {
+        try {
+            await WebRTCModule.senderReplaceTrack(this._peerConnectionId, this._id, track ? track.id : null);
+        } catch(e) {
+            return;
+        }
+
+        this._track = track;
+    }
+
+    static getCapabilities(kind: "audio" | "video"): RTCRtpCapabilities {
+        if (kind === "audio") {
+            return DEFAULT_AUDIO_CAPABILITIES;
+        }
+
+        if (!senderCapabilities) {
+            throw new Error("sender Capabilities are null");
+        }
+        return senderCapabilities;
+    }
+
+    getParameters(): RTCRtpSendParameters {
+        return this._rtpParameters;
+    }
+
+    setParameters(parameters: RTCRtpSendParameters): Promise<void> {
+        return WebRTCModule.senderSetParameters(this._peerConnectionId,
+                this._id,
+                JSON.parse(JSON.stringify(parameters)))// This allows us to get rid of private "underscore properties"
+            .then((newParameters) => {
+                this._rtpParameters = new RTCRtpSendParameters(newParameters);
+            });
+    }
+
+
+    get track() {
+        return this._track;
+    }
+
+    get id() {
+        return this._id;
+    }
+}

--- a/src/RTCRtpTransceiver.ts
+++ b/src/RTCRtpTransceiver.ts
@@ -1,0 +1,125 @@
+import { defineCustomEventTarget } from 'event-target-shim';
+import { NativeModules } from 'react-native';
+import { addListener, removeListener } from './EventEmitter';
+import RTCRtpSender from './RTCRtpSender';
+import RTCErrorEvent from './RTCErrorEvent';
+import RTCRtpReceiver from './RTCRtpReceiver';
+
+const {WebRTCModule} = NativeModules;
+
+const TRANSCEIVER_EVENTS = [
+    'error'
+];
+
+export default class RTCRtpTransceiver extends defineCustomEventTarget(...TRANSCEIVER_EVENTS) {
+    _peerConnectionId: number;
+    _sender: RTCRtpSender;
+    _receiver: RTCRtpReceiver;
+
+    _id: string;
+    _mid: string | null = null;
+    _direction: string;
+    _currentDirection: string;
+    _stopped: boolean;
+
+    constructor(args: {
+        peerConnectionId: number,
+        id: string,
+        isStopped: boolean,
+        direction: string,
+        currentDirection: string,
+        mid?: string,
+        sender: RTCRtpSender,
+        receiver: RTCRtpReceiver,
+    }) {
+        super();
+        this._peerConnectionId = args.peerConnectionId;
+        this._id = args.id;
+        this._mid = args.mid ? args.mid : null;
+        this._direction = args.direction;
+        this._currentDirection = args.currentDirection;
+        this._stopped = args.isStopped;
+        this._sender = args.sender;
+        this._receiver = args.receiver;
+        this._registerEvents();
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    get mid() {
+        return this._mid;
+    }
+
+    get stopped() {
+        return this._stopped;
+    }
+
+    get direction() {
+        return this._direction;
+    }
+
+    set direction(val) {
+        if (!['sendonly', 'recvonly', 'sendrecv', 'inactive'].includes(val)) {
+            throw new TypeError('Invalid direction provided');
+        }
+
+        if (this._stopped) {
+            throw Error('Transceiver Stopped');
+        }
+
+        if (this._direction === val) {
+            return;
+        }
+
+        WebRTCModule.transceiverSetDirection(this._peerConnectionId, this.id, val)
+        this._direction = val;
+    }
+
+    get currentDirection() {
+        return this._currentDirection;
+    }
+
+    get sender() {
+        return this._sender;
+    }
+
+    get receiver() {
+        return this._receiver;
+    }
+
+    stop() {
+        if (this._stopped) {
+            return;
+        }
+        WebRTCModule.transceiverStop(this._peerConnectionId, this.id);
+    }
+
+    _registerEvents(): void {
+        addListener(this, 'transceiverStopSuccessful', ev => {
+            if (ev.peerConnectionId !== this._peerConnectionId || ev.transceiverId !== this._id) {
+                return;
+            }
+            this._stopped = true;
+            this._direction = 'stopped'
+            this._currentDirection = 'stopped';
+            this._mid = null;
+            removeListener(this);
+        });
+
+        addListener(this, 'transceiverOnError', ev => {
+            if (ev.info.peerConnectionId !== this._peerConnectionId || ev.info.transceiverId !== this._id) {
+                return;
+            }
+            if (ev.func === 'stopTransceiver') {
+                this._stopped = false;
+            } else if (ev.func === 'setDirection') {
+                this._direction = ev.info.oldDirection;
+            }
+
+            // @ts-ignore
+            this.dispatchEvent(new RTCErrorEvent('error', ev.func, ev.message));
+        });
+    }
+}

--- a/src/RTCTrackEvent.ts
+++ b/src/RTCTrackEvent.ts
@@ -1,0 +1,21 @@
+
+import MediaStream from './MediaStream';
+import type MediaStreamTrack from './MediaStreamTrack';
+import RTCRtpReceiver from './RTCRtpReceiver';
+import RTCRtpTransceiver from './RTCRtpTransceiver';
+
+export default class RTCTrackEvent {
+    type: string;
+    readonly streams: MediaStream[] = [];
+    readonly transceiver: RTCRtpTransceiver;
+    readonly receiver: RTCRtpReceiver | null;
+    readonly track: MediaStreamTrack | null;
+
+    constructor(type: string, eventInitDict: { streams: MediaStream[], transceiver: RTCRtpTransceiver }) {
+        this.type = type.toString();
+        this.streams = eventInitDict.streams;
+        this.transceiver = eventInitDict.transceiver;
+        this.receiver = eventInitDict.transceiver.receiver;
+        this.track = eventInitDict.transceiver.receiver ? eventInitDict.transceiver.receiver.track : null;
+    }
+}

--- a/src/RTCUtil.ts
+++ b/src/RTCUtil.ts
@@ -12,7 +12,7 @@ const FACING_MODES = [ 'user', 'environment' ];
 
 const ASPECT_RATIO = 16 / 9;
 
-const STANDARD_OA_OPTIONS = {
+const STANDARD_OFFER_OPTIONS = {
     icerestart: 'IceRestart',
     offertoreceiveaudio: 'OfferToReceiveAudio',
     offertoreceivevideo: 'OfferToReceiveVideo',
@@ -133,12 +133,12 @@ export function deepClone<T>(obj: T): T {
 }
 
 /**
- * Normalize options passed to createOffer() / createAnswer().
+ * Normalize options passed to createOffer().
  *
  * @param options - user supplied options
  * @return Normalized options
  */
-export function normalizeOfferAnswerOptions(options: object = {}): object {
+export function normalizeOfferOptions(options: object = {}): object {
     const newOptions = {};
 
     if (!options) {
@@ -148,7 +148,7 @@ export function normalizeOfferAnswerOptions(options: object = {}): object {
     // Convert standard options into WebRTC internal constant names.
     // See: https://github.com/jitsi/webrtc/blob/0cd6ce4de669bed94ba47b88cb71b9be0341bb81/sdk/media_constraints.cc#L113
     for (const [key, value] of Object.entries(options)) {
-        const newKey = STANDARD_OA_OPTIONS[key.toLowerCase()];
+        const newKey = STANDARD_OFFER_OPTIONS[key.toLowerCase()];
         if (newKey) {
             newOptions[newKey] = String(Boolean(value));
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,49 @@
-import ScreenCapturePickerView from './ScreenCapturePickerView';
-import RTCPeerConnection from './RTCPeerConnection';
 import RTCIceCandidate from './RTCIceCandidate';
+import RTCPeerConnection from './RTCPeerConnection';
+import RTCRtpReceiver from './RTCRtpReceiver';
+import RTCRtpSender from './RTCRtpSender';
+import RTCRtpTransceiver from './RTCRtpTransceiver';
+import RTCRtpCapabilities from './RTCRtpCapabilities';
+import RTCRtpCodecCapability from './RTCRtpCodecCapability';
+import RTCRtpEncodingParameters from './RTCRtpEncodingParameters';
+import RTCRtpCodecParameters from './RTCRtpCodecParameters';
+import RTCRtpParameters from './RTCRtpParameters';
+import RTCRtcpParameters from './RTCRtcpParameters';
+import RTCRtpHeaderExtension from './RTCRtpHeaderExtension';
+import RTCRtpSendParameters from './RTCRtpSendParameters';
+import RTCRtpReceiveParameters from './RTCRtpReceiveParameters';
 import RTCSessionDescription from './RTCSessionDescription';
+import RTCErrorEvent from './RTCErrorEvent';
 import RTCView from './RTCView';
+import ScreenCapturePickerView from './ScreenCapturePickerView';
 import MediaStream from './MediaStream';
 import MediaStreamTrack from './MediaStreamTrack';
 import mediaDevices from './MediaDevices';
 import permissions from './Permissions';
+import Logger from './Logger';
+
+Logger.enable('*');
+//Logger.enable(`*,-${Logger.ROOT_PREFIX}:*:DEBUG`);
 
 export {
-    ScreenCapturePickerView,
-    RTCPeerConnection,
     RTCIceCandidate,
+    RTCPeerConnection,
     RTCSessionDescription,
     RTCView,
+    ScreenCapturePickerView,
+    RTCRtpTransceiver,
+    RTCRtpReceiver,
+    RTCRtpSender,
+    RTCErrorEvent,
+    RTCRtpCapabilities,
+    RTCRtpCodecCapability,
+    RTCRtpCodecParameters,
+    RTCRtpEncodingParameters,
+    RTCRtpParameters,
+    RTCRtpSendParameters,
+    RTCRtpReceiveParameters,
+    RTCRtcpParameters,
+    RTCRtpHeaderExtension,
     MediaStream,
     MediaStreamTrack,
     mediaDevices,
@@ -35,9 +65,24 @@ function registerGlobals(): void {
     global.navigator.mediaDevices.getDisplayMedia = mediaDevices.getDisplayMedia.bind(mediaDevices);
     global.navigator.mediaDevices.enumerateDevices = mediaDevices.enumerateDevices.bind(mediaDevices);
 
-    global.RTCPeerConnection = RTCPeerConnection;
     global.RTCIceCandidate = RTCIceCandidate;
+    global.RTCPeerConnection = RTCPeerConnection;
+    global.RTCRtpReceiver = RTCRtpReceiver;
+    global.RTCRtpSender = RTCRtpReceiver;
     global.RTCSessionDescription = RTCSessionDescription;
     global.MediaStream = MediaStream;
     global.MediaStreamTrack = MediaStreamTrack;
+    global.RTCRtpTransceiver = RTCRtpTransceiver;
+    global.RTCRtpReceiver = RTCRtpReceiver;
+    global.RTCRtpSender = RTCRtpSender;
+    global.RTCErrorEvent = RTCErrorEvent;
+    global.RTCRtpCapabilities = RTCRtpCapabilities;
+    global.RTCRtpCodecCapability = RTCRtpCodecCapability;
+    global.RTCRtpCodecParameters = RTCRtpCodecParameters;
+    global.RTCRtpEncodingParameters = RTCRtpEncodingParameters;
+    global.RTCRtpParameters = RTCRtpParameters;
+    global.RTCRtpSendParameters = RTCRtpSendParameters;
+    global.RTCRtpReceiverParameters = RTCRtpReceiveParameters;
+    global.RTCRtcpParameters = RTCRtcpParameters;
+    global.RTCRtpHeaderExtension = RTCRtpHeaderExtension;
 }


### PR DESCRIPTION
This PR adds support for the unified plan transceivers API. This mainly adds the following APIs to RTCPeerConnection: 
```
addTransceiver(...)
getTransceivers()
addTrack(...)
removeTrack(...)
``` 
Along with the required classes like `RTCRtpTransceiver`, `RTCRtpSender`, etc...