### PR TITLE
Type RTCView props

### DIFF
--- a/src/RTCView.ts
+++ b/src/RTCView.ts
@@ -57,4 +57,9 @@ import { requireNativeComponent } from 'react-native';
  * zOrder: number
  */
 
-export default requireNativeComponent('RTCVideoView');
+export default requireNativeComponent('RTCVideoView') as HostComponent<{
+  mirror?: boolean;
+  objectFit?: "contain" | "cover";
+  streamURL: string;
+  zOrder?: number;
+}>;


### PR DESCRIPTION
Typescript does not like when we use any of the props documented for this component, to solve this I've added them to the exported component.