### PR TITLE
video effect registry done

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -18,6 +18,10 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
+import com.oney.WebRTCModule.videoEffects.ProcessorProvider;
+import com.oney.WebRTCModule.videoEffects.VideoEffectProcessor;
+import com.oney.WebRTCModule.videoEffects.VideoFrameProcessor;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -388,6 +392,38 @@ class GetUserMediaImpl {
         videoCaptureController.startCapture();
 
         return track;
+    }
+
+    /**
+     * Set video effect to the TrackPrivate corresponding to the trackId with the help of VideoEffectProcessor
+     * corresponding to the name.
+     * @param trackId TrackPrivate id
+     * @param name VideoEffectProcessor name
+     */
+    void setVideoEffect(String trackId, String name) {
+        TrackPrivate track = tracks.get(trackId);
+
+        if (track != null && track.videoCaptureController instanceof CameraCaptureController) {
+            VideoSource videoSource = (VideoSource) track.mediaSource;
+            SurfaceTextureHelper surfaceTextureHelper = track.surfaceTextureHelper;
+
+            if (name != null) {
+                VideoFrameProcessor videoFrameProcessor = ProcessorProvider.getProcessor(name);
+
+                if (videoFrameProcessor == null) {
+                    Log.e(TAG, "no videoFrameProcessor associated with this name");
+                    return;
+                }
+
+                VideoEffectProcessor videoEffectProcessor = new VideoEffectProcessor(videoFrameProcessor,
+                        surfaceTextureHelper);
+                videoSource.setVideoProcessor(videoEffectProcessor);
+
+            } else {
+                videoSource.setVideoProcessor(null);
+            }
+
+        }
     }
 
     /**

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -895,6 +895,13 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void mediaStreamTrackSetVideoEffect(String id, String name) {
+        ThreadUtils.runOnExecutor(() -> {
+                getUserMediaImpl.setVideoEffect(id, name);
+        });
+    }
+
+    @ReactMethod
     public void peerConnectionSetConfiguration(ReadableMap configuration,
                                                int id) {
         ThreadUtils.runOnExecutor(() -> {

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/ProcessorProvider.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/ProcessorProvider.java
@@ -1,0 +1,37 @@
+package com.oney.WebRTCModule.videoEffects;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages VideoFrameProcessorFactoryInterfaces corresponding to name using hashmap, and provides
+ * get, add and remove functionality.
+ */
+public class ProcessorProvider {
+    private static Map<String, VideoFrameProcessorFactoryInterface> methodMap = new HashMap<String, VideoFrameProcessorFactoryInterface>();
+    
+    public static VideoFrameProcessor getProcessor(String name) {
+        if (methodMap.containsKey(name)) {
+            return methodMap.get(name).build();
+        } else{
+            return null;
+        } 
+    }
+
+    public static void addProcessor(String name,
+            VideoFrameProcessorFactoryInterface videoFrameProcessorFactoryInterface) {
+        if (name != null && videoFrameProcessorFactoryInterface != null) {
+            methodMap.put(name, videoFrameProcessorFactoryInterface);
+        } else{
+             throw new NullPointerException("Name or VideoFrameProcessorFactry can not be null");
+        }
+    }
+
+    public static void removeProcessor(String name) {
+        if (name != null && methodMap.containsKey(name)) {
+            methodMap.remove(name);
+        } else{
+            throw new RuntimeException("VideoFrameProcessorFactry with " + name + " does not exist");
+        }
+    }
+}

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
@@ -1,0 +1,57 @@
+package com.oney.WebRTCModule.videoEffects;
+
+import org.webrtc.SurfaceTextureHelper;
+import org.webrtc.VideoFrame;
+import org.webrtc.VideoProcessor;
+import org.webrtc.VideoSink;
+
+/**
+ * Lightweight abstraction for an object that can receive video frames, process and add effects in
+ * them, and pass them on to another object.
+ */
+public class VideoEffectProcessor implements VideoProcessor {
+    private VideoSink mSink;
+    final private SurfaceTextureHelper textureHelper;
+    final private VideoFrameProcessor videoFrameProcessor;
+
+    public VideoEffectProcessor(VideoFrameProcessor processor, SurfaceTextureHelper textureHelper) {
+        this.textureHelper = textureHelper;
+        this.videoFrameProcessor = processor;
+    }
+
+    @Override
+    public void onCapturerStarted(boolean success) {
+
+    }
+
+    @Override
+    public void onCapturerStopped() {
+
+    }
+
+    @Override
+    public void setSink(VideoSink sink) {
+        mSink = sink;
+    }
+
+    /**
+     * Called just after the frame is captured.
+     * Will process the VideoFrame with the help of VideoFrameProcessor and send the processed
+     * VideoFrame back to webrtc using onFrame method in VideoSink.
+     * @param frame raw VideoFrame received from webrtc.
+     */
+    @Override
+    public void onFrameCaptured(VideoFrame frame) {
+        frame.retain();
+        VideoFrame outputFrame = videoFrameProcessor.process(frame, textureHelper);
+
+        if (outputFrame == null) {
+            mSink.onFrame(frame);
+            frame.release();
+            return;
+        }
+        mSink.onFrame(outputFrame);
+        outputFrame.release();
+        frame.release();
+    }
+}

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessor.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessor.java
@@ -1,0 +1,19 @@
+package com.oney.WebRTCModule.videoEffects;
+
+import org.webrtc.SurfaceTextureHelper;
+import org.webrtc.VideoFrame;
+
+/**
+ * Interface contains process method to process VideoFrame.
+ * The caller takes ownership of the object.
+ */
+public interface VideoFrameProcessor {
+    /**
+     * Applies the image processing algorithms to the frame. Returns the processed frame.
+     * The caller is responsible for releasing the returned frame.
+     * @param frame raw videoframe which need to be processed
+     * @param textureHelper
+     * @return processed videoframe which will rendered
+     */
+    public VideoFrame process(VideoFrame frame, SurfaceTextureHelper textureHelper);
+}

--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessorFactoryInterface.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessorFactoryInterface.java
@@ -1,0 +1,13 @@
+package com.oney.WebRTCModule.videoEffects;
+
+/**
+ * Factory for creating VideoFrameProcessor instances.
+ */
+public interface VideoFrameProcessorFactoryInterface {
+
+   /**
+   * Dynamically allocates a VideoFrameProcessor instance and returns a pointer to it.
+   * The caller takes ownership of the object.
+   */
+    public VideoFrameProcessor build();
+}

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -79,6 +79,16 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
     }
 
+    _setVideoEffect(name:string){
+        if (this.remote) {
+            throw new Error('Not implemented for remote tracks');
+        }
+        if (this.kind !== 'video') {
+            throw new Error('Only implemented for video tracks');
+        }
+        WebRTCModule.mediaStreamTrackSetVideoEffect(this.id, name);
+    }
+
     applyConstraints(): never {
         throw new Error('Not implemented.');
     }


### PR DESCRIPTION
this is the video effect registry

to create a video effect you have to implement VideoFrameProcessorFactoryInterface

for example :
`
import org.webrtc.*;
import com.oney.WebRTCModule.videoEffect.VideoFrameProcessor;
import com.oney.WebRTCModule.videoEffect.VideoFrameProcessorFactoryInterface;

public class Rotate90Factory implements VideoFrameProcessorFactoryInterface {

    public VideoFrameProcessor build() {
        return new VideoFrameProcessor() {
            @Override
            public VideoFrame process(VideoFrame frame, SurfaceTextureHelper textureHelper) {
                return new VideoFrame(frame.getBuffer().toI420(), 0, frame.getTimestampNs());
            }
        };
    }
}`


then you have to add this processor in processor map 

`
import com.oney.WebRTCModule.videoEffect.ProcessorMap;

@ReactMethod
    public void addMethods() {
        Rotate90Factory rotate90 = new Rotate90Factory();
        ProcessorMap.addProcessor("rotate90", rotate90);
        ProcessorMap.addProcessor("rotate270", () -> (VideoFrameProcessor) (frame, textureHelper) -> new VideoFrame(frame.getBuffer().toI420(), 180, frame.getTimestampNs()));

    }
`

your videoEffect is registered now 

to apply this videoEffect you have to call mediaStreamTrack._setVideoEffect(name);
and to remove this effect you just call mediaStreamTrack._setVideoEffect(null);

`
  const onRegisterVideoEffect = () => {
    stream.getVideoTracks().forEach(track => {
      track._setVideoEffect('rotate90');
    });
  };


  const onDiscardVideoEffect = () => {
    stream.getVideoTracks().forEach(track => {
      track._setVideoEffect(null);
    });
  };`

