### PR TITLE
sendEncodings support

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/SerializeUtils.java
+++ b/android/src/main/java/com/oney/WebRTCModule/SerializeUtils.java
@@ -126,12 +126,10 @@ public class SerializeUtils {
       WritableArray headerExtensions = Arguments.createArray();
       WritableMap rtcp = Arguments.createMap();
 
-      
       // Preparing RTCP
       rtcp.putString("cname", params.getRtcp().getCname());
       rtcp.putBoolean("reducedSize", params.getRtcp().getReducedSize());
-      
-      
+
       // Preparing header extensions
       params.getHeaderExtensions().forEach(extension -> {
         WritableMap extensionMap = Arguments.createMap();
@@ -145,6 +143,9 @@ public class SerializeUtils {
       params.encodings.forEach(encoding -> {
         WritableMap encodingMap = Arguments.createMap();
         encodingMap.putBoolean("active", encoding.active);
+        if (encoding.rid != null) {
+            encodingMap.putString("rid", encoding.rid);
+        }
         // Since they return integer objects that are nullable,
         // while the map does not accept nullable integer values.
         if (encoding.maxBitrateBps != null) {
@@ -207,12 +208,13 @@ public class SerializeUtils {
         ReadableMap encodingUpdate = encodingsArray.getMap(i);
         RtpParameters.Encoding encoding = encodings.get(i);
         // Dealing with nullable Integers
-        Integer maxBitrate = encodingUpdate.hasKey("maxBitrate")? encodingUpdate.getInt("maxBitrate") : null;
-        Integer maxFramerate = encodingUpdate.hasKey("maxFramerate")? encodingUpdate.getInt("maxFramerate") : null;
-        Double scaleResolutionDownBy = encodingUpdate.hasKey("scaleResolutionDownBy")? 
+        Integer maxBitrate = encodingUpdate.hasKey("maxBitrate") ? encodingUpdate.getInt("maxBitrate") : null;
+        Integer maxFramerate = encodingUpdate.hasKey("maxFramerate") ? encodingUpdate.getInt("maxFramerate") : null;
+        Double scaleResolutionDownBy = encodingUpdate.hasKey("scaleResolutionDownBy") ? 
           encodingUpdate.getDouble("scaleResolutionDownBy") : null;
         
         encoding.active = encodingUpdate.getBoolean("active");
+        encoding.rid = encodingUpdate.getString("rid");
         encoding.maxBitrateBps = maxBitrate;
         encoding.maxFramerate = maxFramerate;
         encoding.scaleResolutionDownBy = scaleResolutionDownBy;

--- a/ios/RCTWebRTC/SerializeUtils.m
+++ b/ios/RCTWebRTC/SerializeUtils.m
@@ -95,9 +95,12 @@
     
     for (RTCRtpEncodingParameters *encoding in params.encodings) {
         NSMutableDictionary *encodingDictionary = [NSMutableDictionary new];
-        
+
         encodingDictionary[@"active"] = [NSNumber numberWithBool: encoding.isActive];
-               
+
+        if (encoding.rid) {
+            encodingDictionary[@"rid"] = encoding.rid;
+        }
         if (encoding.maxBitrateBps) {
             encodingDictionary[@"maxBitrate"] = encoding.maxBitrateBps;
         }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -451,8 +451,17 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionAddTransceiver:(nonnull NSN
                 if (streamIds) {
                     [transceiverInit setStreamIds:streamIds];
                 }
+
+                NSArray *encodingsArray = [initOptions objectForKey:@"sendEncodings"];
+                if (encodingsArray) {
+                    NSMutableArray<RTCRtpEncodingParameters *> *sendEncodings = [NSMutableArray new];
+                    for (NSDictionary* encoding in encodingsArray) {
+                        [sendEncodings addObject:[self parseEncoding:encoding]];
+                    }
+                    [transceiverInit setSendEncodings:sendEncodings];
+                }
             }
-            
+
             transceiver = [peerConnection addTransceiverWithTrack:track init:transceiverInit];
         } else {
             RCTLogWarn(@"peerConnectionAddTransceiver() no type nor trackId provided in options");
@@ -516,6 +525,29 @@ RCT_EXPORT_METHOD(peerConnectionRemoveTrack:(nonnull NSNumber *)objectID
 }
 
 // TODO: move these below to some SerializeUrils file
+
+- (RTCRtpEncodingParameters*)parseEncoding:(NSDictionary*)params
+{
+    RTCRtpEncodingParameters *encoding = [RTCRtpEncodingParameters new];
+
+    if (params[@"rid"] != nil) {
+      [encoding setRid:params[@"rid"]];
+    }
+    if (params[@"active"] != nil) {
+      [encoding setIsActive:((NSNumber*)params[@"active"]).boolValue];
+    }
+    if (params[@"maxBitrate"] != nil) {
+      [encoding setMaxBitrateBps:(NSNumber*)params[@"maxBitrate"]];
+    }
+    if (params[@"maxFramerate"] != nil) {
+      [encoding setMaxFramerate:(NSNumber*)params[@"maxFramerate"]];
+    }
+    if (params[@"scaleResolutionDownBy"] != nil) {
+      [encoding setScaleResolutionDownBy:(NSNumber*)params[@"scaleResolutionDownBy"]];
+    }
+
+    return encoding;
+}
 
 /**
  * Constructs a JSON <tt>NSString</tt> representation of a specific

--- a/ios/RCTWebRTC/WebRTCModule+Transceivers.m
+++ b/ios/RCTWebRTC/WebRTCModule+Transceivers.m
@@ -199,17 +199,18 @@ RCT_EXPORT_METHOD(transceiverStop:(nonnull NSNumber *) objectID
     for (int i = 0; i < [encodingsArray count]; i++) {
         NSDictionary *encodingUpdate = encodingsArray[i];
         RTCRtpEncodingParameters *encoding = encodings[i];
-        
-        [encoding setIsActive: encodingUpdate[@"active"]];
+
+        encoding.isActive = encodingUpdate[@"active"];
+        encoding.rid = encodingUpdate[@"rid"];
         encoding.maxBitrateBps = encodingUpdate[@"maxBitrate"];
         encoding.maxFramerate =  encodingUpdate[@"maxFramerate"];
         encoding.scaleResolutionDownBy = encodingUpdate[@"scaleResolutionDownBy"];
     }
-    
+
     if ([options objectForKey:@"degradationPreference"]) {
         params.degradationPreference = [options objectForKey:@"degradationPreference"];
     }
-    
+
     return params;
 }
 

--- a/src/RTCRtpEncodingParameters.ts
+++ b/src/RTCRtpEncodingParameters.ts
@@ -1,20 +1,27 @@
 
 export default class RTCRtpEncodingParameters {
     readonly active: boolean;
+    _rid: string | null;
     _maxFramerate: number | null;
     _maxBitrate: number | null;
     _scaleResolutionDownBy: number | null;
 
     constructor(init: {
         active: boolean,
+        rid?: string;
         maxFramerate?: number;
         maxBitrate?: number;
         scaleResolutionDownBy?: number;
     }) {
         this.active = init.active;
+        this._rid = init.rid ?? null;
         this._maxBitrate = init.maxBitrate ?? null;
         this._maxFramerate = init.maxFramerate ?? null;
         this._scaleResolutionDownBy = init.scaleResolutionDownBy ?? null;
+    }
+
+    get rid() {
+        return this._rid;
     }
 
     get maxFramerate() {
@@ -51,6 +58,10 @@ export default class RTCRtpEncodingParameters {
         const obj = {
             active: this.active,
         };
+
+        if (this._rid !== null) {
+            obj['rid'] = this._rid;
+        }
 
         if (this._maxBitrate !== null) {
             obj['maxBitrate'] = this._maxBitrate;

--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -29,20 +29,28 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
     degradationPreference: DegradationPreferenceType | null;
     constructor(init: RTCRtpParametersInit & {
         transactionId: string,
-        encodings: RTCRtpEncodingParameters[],
+        encodings: any[],
         degradationPreference?: string
     }) {
         super(init);
         this.transactionId = init.transactionId;
-        this.encodings = init.encodings;
+        this.encodings = [];
         this.degradationPreference = init.degradationPreference ?
             DegradationPreference.fromNative(init.degradationPreference) : null;
+
+        for (const enc of init.encodings) {
+            this.encodings.push(new RTCRtpEncodingParameters(enc));
+        }
     }
 
     toJSON() {
-        const obj = {
-            encodings: this.encodings,
+        const obj: any = {
+            encodings: [],
         };
+
+        for (const enc of this.encodings) {
+            obj.encodings.push(enc.toJSON());
+        }
 
         if (this.degradationPreference !== null) {
             obj['degradationPreference'] = DegradationPreference.toNative(this.degradationPreference);


### PR DESCRIPTION
Android is tested and working but unsure about iOS as of yet 😄 

Including the following on the init array for a sending Transceiver seems to give the correct `SDP offer`.
```
sendEncodings: [
	{
		rid: 'h',
		maxBitrate: 1200 * 1024
	},
	{
		rid: 'm',
		maxBitrate: 600 * 1024,
		scaleResolutionDownBy: 2
	},
	{
		rid: 'l',
		maxBitrate: 300 * 1024,
		scaleResolutionDownBy: 4
	}
]
```

The resulting `SDP` now includes the following.
```
a=rid:h send
a=rid:m send
a=rid:l send
a=simulcast:send h;m;l
```
I haven't gone as far as to actually test if simulcasting actually works or needs extra implementation.