### PR TITLE
Fix RTCPeerConnection.addTrack signature

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -232,13 +232,13 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
     /**
      * @brief Adds a new track to the {@link RTCPeerConnection},
-     * and indicates that it is contained in the specified {@link MediaStream} array.
-     * This method has to be synchronous as the W3C API expects a track to be return
+     * and indicates that it is contained in the specified {@link MediaStream}s.
+     * This method has to be synchronous as the W3C API expects a track to be returned
      * @param {MediaStreamTrack} track The track to be added
-     * @param {MediaStream[]} streams An array of streams the track needs to be added to
+     * @param {...MediaStream} streams One or more {@link MediaStream}s the track needs to be added to
      * https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtrack
      */
-    addTrack(track: MediaStreamTrack, streams: MediaStream[] = []): RTCRtpSender {
+    addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender {
         log.debug(`${this._peerConnectionId} addTrack`);
 
         if (this.connectionState === 'closed') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import Logger from './Logger';
 import mediaDevices from './MediaDevices';
 import MediaStream from './MediaStream';
 import MediaStreamTrack from './MediaStreamTrack';
+import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import permissions from './Permissions';
 import RTCErrorEvent from './RTCErrorEvent';
 import RTCIceCandidate from './RTCIceCandidate';
@@ -56,6 +57,7 @@ function registerGlobals(): void {
     global.RTCSessionDescription = RTCSessionDescription;
     global.MediaStream = MediaStream;
     global.MediaStreamTrack = MediaStreamTrack;
+    global.MediaStreamTrackEvent = MediaStreamTrackEvent;
     global.RTCRtpTransceiver = RTCRtpTransceiver;
     global.RTCRtpReceiver = RTCRtpReceiver;
     global.RTCRtpSender = RTCRtpSender;


### PR DESCRIPTION
See issue: https://github.com/react-native-webrtc/react-native-webrtc/issues/1197

This PR updates the signature of RTCPeerConnection.addTrack() to allow a rest parameter for the second argument, accepting one or more `MediaStream`s rather than an array of `MediaStream`s.

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addTrack

Additionally, this PR updates `registerGlobals()` to expose the `MediaStreamTrackEvent` interface in the global context. This should improve compatibility with libraries like [SIP.js](https://github.com/onsip/SIP.js) which expect this interface to be available globally (example usage [here](https://github.com/onsip/SIP.js/blob/main/src/platform/web/session-description-handler/session-description-handler.ts#L181)).

https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackEvent