### PR TITLE
ios: ensure property not null to prevent crash

### DIFF
--- a/ios/RCTWebRTC/RCTConvert+WebRTC.m
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.m
@@ -45,6 +45,16 @@
     RCTLogConvertError(json, @".candidate must not be null");
     return nil;
   }
+  
+  if (json[@"sdpMid"] == nil) {
+    RCTLogConvertError(json, @".sdpMid must not be null");
+    return nil;
+  }
+
+  if (json[@"sdpMLineIndex"] == nil) {
+    RCTLogConvertError(json, @".sdpMLineIndex must not be null");
+    return nil;
+  }
 
   NSString *sdp = json[@"candidate"];
   RCTLogTrace(@"%@ <- candidate", sdp);

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -1,9 +1,13 @@
 export default class RTCIceCandidate {
     candidate: string;
-    sdpMLineIndex: number | null;
-    sdpMid: string | null;
+    sdpMLineIndex: number;
+    sdpMid: string;
 
     constructor({ candidate = '', sdpMLineIndex = null, sdpMid = null }) {
+        if (sdpMLineIndex === null || sdpMid === null) {
+            throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null');
+        }
+
         this.candidate = candidate;
         this.sdpMLineIndex = sdpMLineIndex;
         this.sdpMid = sdpMid;

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -1,22 +1,12 @@
 export default class RTCIceCandidate {
     candidate: string;
-    sdpMLineIndex: number;
-    sdpMid: string;
+    sdpMLineIndex: number | null;
+    sdpMid: string | null;
 
-    constructor(info) {
-        if (typeof info?.candidate !== 'string') {
-            throw new TypeError('`candidate` must be string');
-        }
-        if (typeof info?.sdpMLineIndex !== 'number') {
-            throw new TypeError('`sdpMLineIndex` must be number');
-        }
-        if (typeof info?.sdpMid !== 'string') {
-            throw new TypeError('`sdpMid` must be string');
-        }
-
-        this.candidate = info.candidate;
-        this.sdpMLineIndex = info.sdpMLineIndex;
-        this.sdpMid = info.sdpMid;
+    constructor({ candidate = '', sdpMLineIndex = null, sdpMid = null }) {
+        this.candidate = candidate;
+        this.sdpMLineIndex = sdpMLineIndex;
+        this.sdpMid = sdpMid;
     }
 
     toJSON() {

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -1,10 +1,19 @@
-
 export default class RTCIceCandidate {
     candidate: string;
     sdpMLineIndex: number;
     sdpMid: string;
 
     constructor(info) {
+        if (typeof info?.candidate !== 'string') {
+            throw new TypeError('`candidate` must be string');
+        }
+        if (typeof info?.sdpMLineIndex !== 'number') {
+            throw new TypeError('`sdpMLineIndex` must be number');
+        }
+        if (typeof info?.sdpMid !== 'string') {
+            throw new TypeError('`sdpMid` must be string');
+        }
+
         this.candidate = info.candidate;
         this.sdpMLineIndex = info.sdpMLineIndex;
         this.sdpMid = info.sdpMid;

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -222,6 +222,13 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
             return;
         }
 
+        if (
+            candidate.sdpMLineIndex === null ||
+            candidate.sdpMLineIndex === undefined ||
+            candidate.sdpMid === null ||
+            candidate.sdpMid === undefined
+        ) throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null or undefined')
+
         const newSdp = await WebRTCModule.peerConnectionAddICECandidate(
             this._peerConnectionId,
             candidate.toJSON ? candidate.toJSON() : candidate

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -227,7 +227,9 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
             candidate.sdpMLineIndex === undefined ||
             candidate.sdpMid === null ||
             candidate.sdpMid === undefined
-        ) throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null or undefined')
+        ) {
+            throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null or undefined');
+        }
 
         const newSdp = await WebRTCModule.peerConnectionAddICECandidate(
             this._peerConnectionId,


### PR DESCRIPTION
Do `addIceCandidate` without `sdpMid` will crash on [this line](https://webrtc.googlesource.com/src/+/refs/heads/main/sdk/objc/api/peerconnection/RTCIceCandidate.mm#65)

In [spec](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/sdpMid) it must not null