### PR TITLE
transceivers: simplify error handling

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -161,16 +161,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             .emit(eventName, params);
     }
 
-    void sendError(String eventName, String funcName, @Nullable String message, @Nullable ReadableMap info) {
-        WritableMap errorInfo = Arguments.createMap();
-        errorInfo.putString("func", funcName);
-        if (info != null)
-            errorInfo.putMap("info", info);
-        if (message != null)
-            errorInfo.putString("message", message);
-        sendEvent(eventName, errorInfo);
-    }
-
     private PeerConnection.IceServer createIceServer(String url) {
         return PeerConnection.IceServer.builder(url).createIceServer();
     }
@@ -644,29 +634,27 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void transceiverStop(int id,
-                                String senderId) {
+    public void transceiverStop(int id, String senderId, Promise promise) {
         ThreadUtils.runOnExecutor(() -> {
-            WritableMap identifier = Arguments.createMap();
-            identifier.putInt("peerConnectionId", id);
-            identifier.putString("transceiverId", senderId);
             try {
                 PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
                 if (pco == null) {
                     Log.d(TAG, "transceiverStop() peerConnectionObserver is null");
-                    // Cannot really report an error specific to RTCRtpTransceiver as the peer connection
-                    // hasn't really been initialized, this call from the web API should technically
-                    // not happen unless both peer connection and transceivers are initialized properly
-                    // That is why constructors or create methods should always be synchronous.
+                    promise.reject(new Exception("Peer Connection is not initialized"));
                     return;
                 }
                 RtpTransceiver transceiver = pco.getTransceiver(senderId);
+                if (transceiver == null) {
+                    Log.w(TAG, "transceiverStop() transceiver is null");
+                    promise.reject(new Exception("Could not get transceiver"));
+                    return;
+                }
 
                 transceiver.stopStandard();
-                sendEvent("transceiverStopSuccessful", identifier);
+                promise.resolve(true);
             } catch (Exception e) {
                 Log.d(TAG, "transceiverStop(): " + e.getMessage());
-                sendError("transceiverOnError", "stopTransceiver", e.getMessage(), identifier);
+                promise.reject(e);
             }
         });
     }
@@ -705,7 +693,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void transceiverSetDirection(int id,
                                         String senderId,
-                                        String direction) {
+                                        String direction,
+                                        Promise promise) {
 
         ThreadUtils.runOnExecutor(() -> {
             WritableMap identifier = Arguments.createMap();
@@ -716,24 +705,22 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
                 if (pco == null) {
                     Log.d(TAG, "transceiverSetDirection() peerConnectionObserver is null");
-                    // Cannot really report an error specific to RTCRtpSender as the peer connection
-                    // hasn't really been initialized, this call from the web API should technically
-                    // not happen unless both peer connection and sender are initialized
+                    promise.reject(new Exception("Peer Connection is not initialized"));
                     return;
                 }
                 RtpTransceiver transceiver = pco.getTransceiver(senderId);
                 if (transceiver == null){
                     Log.d(TAG, "transceiverSetDirection() transceiver is null");
+                    promise.reject(new Exception("Could not get sender"));
                     return;
                 }
 
-                RtpTransceiver.RtpTransceiverDirection oldDirection = transceiver.getDirection();
-                params.putString("oldDirection", SerializeUtils.serializeDirection(oldDirection));
                 transceiver.setDirection(SerializeUtils.parseDirection(direction));
+
+                promise.resolve(true);
             } catch (Exception e) {
                 Log.d(TAG, "transceiverSetDirection(): " + e.getMessage());
-                params.putMap("identifiers", identifier);
-                sendError("transceiverOnError", "setDirection", e.getMessage(), params);
+                promise.reject(e);
             }
         });
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -511,7 +511,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack:(nonnull NSNumb
         ret = [peerConnection removeTrack: sender];
     });
 
-    return ret;
+    return @(ret);
 }
 
 // TODO: move these below to some SerializeUrils file

--- a/ios/RCTWebRTC/WebRTCModule+Transceivers.m
+++ b/ios/RCTWebRTC/WebRTCModule+Transceivers.m
@@ -94,6 +94,7 @@ RCT_EXPORT_METHOD(senderSetParameters:(nonnull NSNumber *) objectID
         if (peerConnection == nil) {
             RCTLogWarn(@"PeerConnection %@ not found in senderSetParameters()", objectID);
             reject(@"E_INVALID", @"Peer Connection is not initialized", nil);
+            return;
         }
 
         RTCRtpTransceiver *transceiver = nil;
@@ -106,7 +107,8 @@ RCT_EXPORT_METHOD(senderSetParameters:(nonnull NSNumber *) objectID
 
         if (transceiver == nil) {
             RCTLogWarn(@"senderSetParameters() transceiver is null");
-            reject(@"E_INVALID", @"Could not get transceive", nil);
+            reject(@"E_INVALID", @"Could not get transceiver", nil);
+            return;
         }
         
         RTCRtpSender *sender = transceiver.sender;
@@ -117,13 +119,16 @@ RCT_EXPORT_METHOD(senderSetParameters:(nonnull NSNumber *) objectID
 }
 
 RCT_EXPORT_METHOD(transceiverSetDirection:(nonnull NSNumber *) objectID
-                            senderId:(NSString *)senderId
-                            direction:(NSString *)direction)
+                                 senderId:(NSString *)senderId
+                                direction:(NSString *)direction
+                                 resolver:(RCTPromiseResolveBlock)resolve
+                                 rejecter:(RCTPromiseRejectBlock)reject)
 {
         RTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
         if (peerConnection == nil) {
             RCTLogWarn(@"transceiverSetDirection() PeerConnection %@ not found in transceiverSetDirection()", objectID);
+            reject(@"E_INVALID", @"Peer Connection is not initialized", nil);
             return;
         }
 
@@ -137,34 +142,30 @@ RCT_EXPORT_METHOD(transceiverSetDirection:(nonnull NSNumber *) objectID
 
         if (transceiver == nil) {
             RCTLogWarn(@"transceiverSetDirection() transceiver is null");
+            reject(@"E_INVALID", @"Could not get transceiver", nil);
             return;
         }
-        
-        NSMutableDictionary *identifier = [NSMutableDictionary new];
-        identifier[@"peerConnectionId"] = objectID;
-        identifier[@"transceiverId"] = senderId;
-        
-        NSMutableDictionary *params = [NSMutableDictionary new];
-        RTCRtpTransceiverDirection oldDirrection = transceiver.direction;
-        params[@"oldDirection"] = [SerializeUtils serializeDirection: oldDirrection];
+
         NSError *error;
         [transceiver setDirection:[SerializeUtils parseDirection:direction] error: &error];
-        
+
         if (error) {
-            [self sendErrorWithEventName: kEventTransceiverOnError
-                                funcName: @"transceiverSetDirection"
-                                 message: [error localizedDescription]
-                                    info: nil];
+            reject(@"E_SET_DIRECTION", @"Could not set direction", error);
+        } else {
+            resolve(@true);
         }
 }
 
 RCT_EXPORT_METHOD(transceiverStop:(nonnull NSNumber *) objectID
-                            senderId:(NSString *)senderId)
+                         senderId:(NSString *)senderId
+                         resolver:(RCTPromiseResolveBlock)resolve
+                         rejecter:(RCTPromiseRejectBlock)reject)
 {
         RTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
         if (peerConnection == nil) {
             RCTLogWarn(@"PeerConnection %@ not found in transceiverStop()", objectID);
+            reject(@"E_INVALID", @"Peer Connection is not initialized", nil);
             return;
         }
 
@@ -178,15 +179,13 @@ RCT_EXPORT_METHOD(transceiverStop:(nonnull NSNumber *) objectID
 
         if (transceiver == nil) {
             RCTLogWarn(@"senderSetParameters() transceiver is null");
+            reject(@"E_INVALID", @"Could not get transceiver", nil);
             return;
         }
 
         [transceiver stopInternal];
-        [self sendEventWithName:kEventTransceiverStopSuccessful
-                              body:@{
-                                @"peerConnectionId": objectID,
-                                @"transceiverId": senderId
-                              }];
+
+        resolve(@true);
 }
 
 - (RTCRtpParameters *) updateParametersWithOptions: (NSDictionary *) options

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -30,11 +30,9 @@ static NSString *const kEventPeerConnectionDidOpenDataChannel = @"peerConnection
 static NSString *const kEventDataChannelStateChanged = @"dataChannelStateChanged";
 static NSString *const kEventDataChannelReceiveMessage = @"dataChannelReceiveMessage";
 static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMuteChanged";
-static NSString *const kEventTransceiverStopSuccessful = @"transceiverStopSuccessful";
 static NSString *const kEventTransceiverOnError = @"transceiverOnError";
 static NSString *const kEventPeerConnectionOnRemoveTrack = @"peerConnectionOnRemoveTrack";
 static NSString *const kEventPeerConnectionOnTrack = @"peerConnectionOnTrack";
-static NSString *const kEventPeerConnectionOnError = @"peerConnectionOnError";
 
 @interface WebRTCModule : RCTEventEmitter <RCTBridgeModule>
 
@@ -52,10 +50,5 @@ static NSString *const kEventPeerConnectionOnError = @"peerConnectionOnError";
                         decoderFactory:(id<RTCVideoDecoderFactory>)decoderFactory;
 
 - (RTCMediaStream*)streamForReactTag:(NSString*)reactTag;
-
-- (void)sendErrorWithEventName: (NSString *) eventName
-                      funcName: (NSString *) funcName
-                       message: (NSString *) message
-                          info: (NSDictionary *) info;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -94,22 +94,6 @@
   return stream;
 }
 
-- (void)sendErrorWithEventName: (NSString *) eventName
-                      funcName: (NSString *) funcName
-                       message: (NSString *) message
-                          info: (NSDictionary *) info {
-    NSMutableDictionary *errorInfo = [NSMutableDictionary new];
-    
-    errorInfo[@"func"] = funcName;
-    if (info)
-        errorInfo[@"info"] = info;
-    if (message)
-        errorInfo[@"message"] = message;
-
-    [self sendEventWithName: kEventPeerConnectionOnError
-                       body: errorInfo];
-}
-
 RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue
@@ -129,11 +113,9 @@ RCT_EXPORT_MODULE();
     kEventDataChannelStateChanged,
     kEventDataChannelReceiveMessage,
     kEventMediaStreamTrackMuteChanged,
-    kEventTransceiverStopSuccessful,
     kEventTransceiverOnError,
     kEventPeerConnectionOnRemoveTrack,
-    kEventPeerConnectionOnTrack,
-    kEventPeerConnectionOnError
+    kEventPeerConnectionOnTrack
   ];
 }
 

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -9,7 +9,6 @@ import MediaStreamTrack from './MediaStreamTrack';
 import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import RTCDataChannel from './RTCDataChannel';
 import RTCDataChannelEvent from './RTCDataChannelEvent';
-import RTCErrorEvent from './RTCErrorEvent';
 import RTCEvent from './RTCEvent';
 import RTCIceCandidate from './RTCIceCandidate';
 import RTCIceCandidateEvent from './RTCIceCandidateEvent';
@@ -603,21 +602,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
             // @ts-ignore
             this.dispatchEvent(new RTCDataChannelEvent('datachannel', { channel }));
-        });
-
-        // Since the current underlying architecture performs certain actions
-        // Asynchronously when the outer web API expects synchronous behaviour
-        // This is the only way to report error on operations for those who wish
-        // to handle them.
-        addListener(this, 'peerConnectionOnError', (ev: any) => {
-            if (ev.info.peerConnectionId !== this._pcId) {
-                return;
-            }
-
-            log.error(`onerror: ${JSON.stringify(ev)}`);
-
-            // @ts-ignore
-            this.dispatchEvent(new RTCErrorEvent('error', ev.func, ev.message));
         });
 
         addListener(this, 'mediaStreamTrackMuteChanged', (ev: any) => {

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -418,12 +418,12 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
     close(): void {
         log.debug(`${this._pcId} close`);
 
-        // According to the W3C spec: https://w3c.github.io/webrtc-pc/#rtcpeerconnection-interface
-        // transceivers have to be stopped
-        this._transceivers.forEach(({ transceiver })=> {
-            transceiver.stop();
-        });
         WebRTCModule.peerConnectionClose(this._pcId);
+
+        // Mark transceivers as stopped.
+        this._transceivers.forEach(({ transceiver })=> {
+            transceiver._setStopped();
+        });
     }
 
     restartIce(): void {

--- a/src/RTCRtpTransceiver.ts
+++ b/src/RTCRtpTransceiver.ts
@@ -1,18 +1,12 @@
-import { defineCustomEventTarget } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
-import { addListener, removeListener } from './EventEmitter';
-import RTCErrorEvent from './RTCErrorEvent';
 import RTCRtpReceiver from './RTCRtpReceiver';
 import RTCRtpSender from './RTCRtpSender';
 
 const { WebRTCModule } = NativeModules;
 
-const TRANSCEIVER_EVENTS = [
-    'error'
-];
 
-export default class RTCRtpTransceiver extends defineCustomEventTarget(...TRANSCEIVER_EVENTS) {
+export default class RTCRtpTransceiver {
     _peerConnectionId: number;
     _sender: RTCRtpSender;
     _receiver: RTCRtpReceiver;
@@ -33,7 +27,6 @@ export default class RTCRtpTransceiver extends defineCustomEventTarget(...TRANSC
         sender: RTCRtpSender,
         receiver: RTCRtpReceiver,
     }) {
-        super();
         this._peerConnectionId = args.peerConnectionId;
         this._id = args.id;
         this._mid = args.mid ? args.mid : null;
@@ -42,7 +35,6 @@ export default class RTCRtpTransceiver extends defineCustomEventTarget(...TRANSC
         this._stopped = args.isStopped;
         this._sender = args.sender;
         this._receiver = args.receiver;
-        this._registerEvents();
     }
 
     get id() {
@@ -74,7 +66,13 @@ export default class RTCRtpTransceiver extends defineCustomEventTarget(...TRANSC
             return;
         }
 
-        WebRTCModule.transceiverSetDirection(this._peerConnectionId, this.id, val);
+        const oldDirection = this._direction;
+
+        WebRTCModule.transceiverSetDirection(this._peerConnectionId, this.id, val)
+            .catch(() => {
+                this._direction = oldDirection;
+            });
+
         this._direction = val;
     }
 
@@ -95,35 +93,12 @@ export default class RTCRtpTransceiver extends defineCustomEventTarget(...TRANSC
             return;
         }
 
-        WebRTCModule.transceiverStop(this._peerConnectionId, this.id);
-    }
-
-    _registerEvents(): void {
-        addListener(this, 'transceiverStopSuccessful', (ev: any) => {
-            if (ev.peerConnectionId !== this._peerConnectionId || ev.transceiverId !== this._id) {
-                return;
-            }
-
-            this._stopped = true;
-            this._direction = 'stopped';
-            this._currentDirection = 'stopped';
-            this._mid = null;
-            removeListener(this);
-        });
-
-        addListener(this, 'transceiverOnError', (ev: any) => {
-            if (ev.info.peerConnectionId !== this._peerConnectionId || ev.info.transceiverId !== this._id) {
-                return;
-            }
-
-            if (ev.func === 'stopTransceiver') {
-                this._stopped = false;
-            } else if (ev.func === 'setDirection') {
-                this._direction = ev.info.oldDirection;
-            }
-
-            // @ts-ignore
-            this.dispatchEvent(new RTCErrorEvent('error', ev.func, ev.message));
-        });
+        WebRTCModule.transceiverStop(this._peerConnectionId, this.id)
+            .then(() => {
+                this._stopped = true;
+                this._direction = 'stopped';
+                this._currentDirection = 'stopped';
+                this._mid = null;
+            });
     }
 }

--- a/src/RTCRtpTransceiver.ts
+++ b/src/RTCRtpTransceiver.ts
@@ -94,11 +94,13 @@ export default class RTCRtpTransceiver {
         }
 
         WebRTCModule.transceiverStop(this._peerConnectionId, this.id)
-            .then(() => {
-                this._stopped = true;
-                this._direction = 'stopped';
-                this._currentDirection = 'stopped';
-                this._mid = null;
-            });
+            .then(() => this._setStopped());
+    }
+
+    _setStopped() {
+        this._stopped = true;
+        this._direction = 'stopped';
+        this._currentDirection = 'stopped';
+        this._mid = null;
     }
 }


### PR DESCRIPTION
Setting the direction and stopping are asynchronous operations, so we can use a promise under the hood to simplify error handling.