### PR TITLE
onAddTrack: Do not skip track if track.id() exists

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -367,13 +367,6 @@ class PeerConnectionObserver implements PeerConnection.Observer {
 
             final MediaStreamTrack track = receiver.track();
 
-            if (remoteTracks.containsKey(track.id())) {
-                // Unlike in the WebRTC spec, the libwebrtc native implementation
-                // fires onTrack on every sRD which has an active receiving transceiver.
-                // So, if we are already keeping track of this transceiver, ignore the event.
-                return;
-            }
-
             if (track.kind().equals(MediaStreamTrack.VIDEO_TRACK_KIND)){
                 videoTrackAdapters.addAdapter((VideoTrack) track);
             }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -801,11 +801,7 @@ RCT_EXPORT_METHOD(peerConnectionRemoveTrack:(nonnull NSNumber *)objectID
         }
         
         RTCMediaStreamTrack *track = rtpReceiver.track;
-        
-        if (peerConnection.remoteTracks[track.trackId]) {
-            return;
-        }
-        
+
         if (track.kind == kRTCMediaStreamTrackKindVideo) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
             [peerConnection addVideoTrackAdapter: videoTrack];


### PR DESCRIPTION
#### Summary
This PR fixes a problem we've noticed when  `peerconnection.onAddTrack` is fired. Mainly, the library skips adding the track if the `track.id()` already exists in the `remoteTracks` map.

This is causing us a problem because a peer can send a video track with an id (e.g., `screen`), and then stop sending the track, then start sending the track again (with the same id, e.g. `screen`). 

The code has this helpful comment (thank you for that, btw):

```
 // Unlike in the WebRTC spec, the libwebrtc native implementation
 // fires onTrack on every sRD which has an active receiving transceiver.
 // So, if we are already keeping track of this transceiver, ignore the event.
```

We were using a fork of `react-native-webrtc` (https://github.com/openland/react-native-webrtc) which did not do this check, and it was working well for us: e.g. https://github.com/openland/react-native-webrtc/blob/master/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java#L510-L514

The spec is a little unclear (at least to me) about what should happen when resending a track that was closed earlier. But it seems that at the very least, `track.id()`s are not guaranteed to be unique (https://blog.mozilla.org/webrtc/rtcrtptransceiver-explored/), and "[if you're sending track ids out-of-band today hoping to correlate local and remote tracks, WebRTC 1.0 will break you](https://blog.mozilla.org/webrtc/the-evolution-of-webrtc/)", and the track ids are not even guaranteed to be the same as the id sent from the peer [point 2 from the W3C draft](https://w3c.github.io/webrtc-pc/#rtcrtpreceiver-interface). That leads me to think we shouldn't rely on them for indexing tracks over time.

So we propose to not use the ids to check if the track already exists. Instead, add tracks when `peerconnection.onAddTrack` is called, and then let the application logic decide on how to handle the `onTrack` event.

#### Alternatives:
- We could index remoteTracks using a synthentic id, either a UUID or `track.Id() + transciever.getMid()` which should be unique even when the same `track.Id()`s are used. But then we would have to maintain a mapping between (the non-unique) `track.Id()` -> (the unique) UUID, and determine which unique track to return when `getTrack(String trackId)` is called.
- Some other solution that you can see that I can't?

As an aside: In an ideal world, there would be a clear way to stop sending a video track and we could clean up the `remoteTracks` map, but there doesn't seem to be a consensus (https://blog.mozilla.org/webrtc/the-evolution-of-webrtc/). E.g., we tried removing the track explicitly and renegotiating, then adding the track again and renegotiating, but that only seems to work on iOS.
