### PR TITLE
pc,track: refactor emitting (un)mute events for remote tracks

### DIFF
--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -2,6 +2,7 @@
 import { defineCustomEventTarget } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
+import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import { deepClone } from './RTCUtil';
 
 const { WebRTCModule } = NativeModules;
@@ -93,6 +94,23 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         }
 
         WebRTCModule.mediaStreamTrackSetVideoEffect(this.id, name);
+    }
+
+    /**
+     * Internal function which is used to set the muted state on remote tracks and
+     * emit the mute / unmute event.
+     *
+     * @param muted Whether the track should be marked as muted / unmuted.
+     */
+    _setMutedInternal(muted: boolean) {
+        if (!this.remote) {
+            throw new Error('Track is not remote!');
+        }
+
+        this._muted = muted;
+
+        // @ts-ignore
+        this.dispatchEvent(new MediaStreamTrackEvent(muted ? 'mute' : 'unmute', { track: this }));
     }
 
     applyConstraints(): never {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -1,8 +1,7 @@
 
-import { defineCustomEventTarget } from 'event-target-shim';
+import { defineCustomEventTarget, Event } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
-import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import { deepClone } from './RTCUtil';
 
 const { WebRTCModule } = NativeModules;
@@ -108,9 +107,7 @@ class MediaStreamTrack extends defineCustomEventTarget(...MEDIA_STREAM_TRACK_EVE
         }
 
         this._muted = muted;
-
-        // @ts-ignore
-        this.dispatchEvent(new MediaStreamTrackEvent(muted ? 'mute' : 'unmute', { track: this }));
+        this.dispatchEvent(new Event(muted ? 'mute' : 'unmute'));
     }
 
     applyConstraints(): never {


### PR DESCRIPTION
- Emit unmute in ontrack
- Emit mute when a remote track is removed
- Add helper function to encapsulate setting the state ane emitting the event