### PR TITLE
iOS: Fix MediaStreamTrack readyState always ended

### DIFF
--- a/ios/RCTWebRTC/SerializeUtils.m
+++ b/ios/RCTWebRTC/SerializeUtils.m
@@ -160,10 +160,10 @@
     NSString *readyState;
     switch (track.readyState) {
         case RTCMediaStreamTrackStateLive:
-            readyState = @"Live";
+            readyState = @"live";
             break;
         case RTCMediaStreamTrackStateEnded:
-            readyState = @"Ended";
+            readyState = @"ended";
             break;
     }
     

--- a/ios/RCTWebRTC/SerializeUtils.m
+++ b/ios/RCTWebRTC/SerializeUtils.m
@@ -161,8 +161,10 @@
     switch (track.readyState) {
         case RTCMediaStreamTrackStateLive:
             readyState = @"Live";
+            break;
         case RTCMediaStreamTrackStateEnded:
             readyState = @"Ended";
+            break;
     }
     
     return @{


### PR DESCRIPTION
Fixes #1219