### PR TITLE
Avoid to call undefined _setMutedInternal function in track.

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -553,7 +553,9 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
             this.dispatchEvent(new RTCTrackEvent('track', eventData));
 
             // Dispatch an unmute event for the track.
-            track._setMutedInternal(false);
+            if (track instanceof MediaStreamTrack) {
+                track._setMutedInternal(false);
+            }
         });
 
         addListener(this, 'peerConnectionOnRemoveTrack', (ev: any) => {
@@ -631,6 +633,10 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                 track
             ] = this.getReceivers().map(r => r.track).filter(t => t?.id === ev.trackId);
 
+            if (track?.readyState.toLowerCase() === 'ended') {
+                return;
+            }
+            
             if (track) {
                 track._setMutedInternal(ev.muted);
             }

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -633,7 +633,7 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                 track
             ] = this.getReceivers().map(r => r.track).filter(t => t?.id === ev.trackId);
 
-            if (track?.readyState.toLowerCase() === 'ended') {
+            if (track?.readyState === 'ended') {
                 return;
             }
             


### PR DESCRIPTION
1. Ensure the type of track is MediaStreamTrack before to do the _setMutedInternal, to prevent the undefined _setMutedInternal function in track.
2. When track state is ended, don't need to do _setMutedInternal, finish the  mediaStreamTrackMuteChanged event directly.