### PR TITLE
RTCRtpReceiver/RTCRtpSender getStats implementation

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1144,6 +1144,31 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void receiverGetStats(int pcId, String receiverId, Promise promise) {
+        ThreadUtils.runOnExecutor(() -> {
+            PeerConnectionObserver pco = mPeerConnectionObservers.get(pcId);
+            if (pco == null || pco.getPeerConnection() == null) {
+                Log.d(TAG, "peerConnectionGetStats() peerConnection is null");
+                promise.reject(new Exception("PeerConnection ID not found"));
+            } else {
+                pco.getFilteredStats(receiverId, true, promise);
+            }
+        });
+    }
+    @ReactMethod
+    public void senderGetStats(int pcId, String senderId, Promise promise) {
+        ThreadUtils.runOnExecutor(() -> {
+            PeerConnectionObserver pco = mPeerConnectionObservers.get(pcId);
+            if (pco == null || pco.getPeerConnection() == null) {
+                Log.d(TAG, "peerConnectionGetStats() peerConnection is null");
+                promise.reject(new Exception("PeerConnection ID not found"));
+            } else {
+                pco.getFilteredStats(senderId, false, promise);
+            }
+        });
+    }
+
+    @ReactMethod
     public void peerConnectionAddICECandidate(int pcId,
                                               ReadableMap candidateMap,
                                               Promise promise) {

--- a/src/RTCRtpReceiver.ts
+++ b/src/RTCRtpReceiver.ts
@@ -1,8 +1,11 @@
+import { NativeModules } from 'react-native';
+
 import MediaStreamTrack from './MediaStreamTrack';
 import RTCRtpCapabilities, { DEFAULT_AUDIO_CAPABILITIES, receiverCapabilities } from './RTCRtpCapabilities';
 import { RTCRtpParametersInit } from './RTCRtpParameters';
 import RTCRtpReceiveParameters from './RTCRtpReceiveParameters';
 
+const { WebRTCModule } = NativeModules;
 
 export default class RTCRtpReceiver {
     _id: string;
@@ -35,6 +38,20 @@ export default class RTCRtpReceiver {
         }
 
         return receiverCapabilities;
+    }
+
+    getStats() {
+        return WebRTCModule.receiverGetStats(this._peerConnectionId, this._id).then(data =>
+            /* On both Android and iOS it is faster to construct a single
+            JSON string representing the Map of StatsReports and have it
+            pass through the React Native bridge rather than the Map of
+            StatsReports. While the implementations do try to be faster in
+            general, the stress is on being faster to pass through the React
+            Native bridge which is a bottleneck that tends to be visible in
+            the UI when there is congestion involving UI-related passing.
+            */
+            new Map(JSON.parse(data))
+        );
     }
 
     getParameters(): RTCRtpReceiveParameters {

--- a/src/RTCRtpSender.ts
+++ b/src/RTCRtpSender.ts
@@ -62,6 +62,20 @@ export default class RTCRtpSender {
         this._rtpParameters = new RTCRtpSendParameters(newParameters);
     }
 
+    getStats() {
+        return WebRTCModule.receiverGetStats(this._peerConnectionId, this._id).then(data =>
+            /* On both Android and iOS it is faster to construct a single
+            JSON string representing the Map of StatsReports and have it
+            pass through the React Native bridge rather than the Map of
+            StatsReports. While the implementations do try to be faster in
+            general, the stress is on being faster to pass through the React
+            Native bridge which is a bottleneck that tends to be visible in
+            the UI when there is congestion involving UI-related passing.
+            */
+            new Map(JSON.parse(data))
+        );
+    }
+
     get track() {
         return this._track;
     }


### PR DESCRIPTION
Looks like native doesn't have direct access to the getStats filtered for receiver/sender, so this is an approximation for `RTCRtpReceiver`/`RTCRtpSender`. Matched against what I saw with chrome web behavior. 

Seems to include these stats (rtpId = receiver/sender id):
* Track with `trackIdentifier === rtpId`
* All `inbound-rtp` (receiver)/`outbound-rtp` (sender) with `trackId === Track.id`
* Any `codec` specified by the inbound/outbound-rtp `codecId` member.
* Any `remote-outbound-rtp` (receiver)/`remote-inbound-rtp` (sender) specified by the inbound/outbound-rtp `ssrc`
* The `media-source` stats with `trackIdentifier === rtpId` (only exists for sender)
* All `certificate` stats
* The `transport` stat
* The `candidate-pair` with `nominated === true`
* The `local-candidate` specified by candidate-pair's `localCandidateId`.
* The `remote-candidate` specified by candidate-pair's `remoteCandidateId`.

I actually didn't see `stream` being returned in any stats on web, whether by PeerConnection or the rtp objects, but I included them in the stats returned here.

----

This could technically be done in JS I think, but there's a warning about performance here, so kept this one native. If this looks acceptable, I'll look into getting an iOS implementation done soon as well.