### PR TITLE
Add ability to create local custom tracks

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -307,7 +307,7 @@ class GetUserMediaImpl {
         displayMediaPromise = null;
     }
 
-    private void createStream(MediaStreamTrack[] tracks, BiConsumer<String, ArrayList<WritableMap>> successCallback) {
+    void createStream(MediaStreamTrack[] tracks, BiConsumer<String, ArrayList<WritableMap>> successCallback) {
         String streamId = UUID.randomUUID().toString();
         MediaStream mediaStream = webRTCModule.mFactory.createLocalMediaStream(streamId);
 
@@ -362,7 +362,7 @@ class GetUserMediaImpl {
         return createVideoTrack(screenCaptureController);
     }
 
-    private VideoTrack createVideoTrack(AbstractVideoCaptureController videoCaptureController) {
+    VideoTrack createVideoTrack(AbstractVideoCaptureController videoCaptureController) {
         videoCaptureController.initializeVideoCapturer();
 
         VideoCapturer videoCapturer = videoCaptureController.videoCapturer;
@@ -499,7 +499,7 @@ class GetUserMediaImpl {
         }
     }
 
-    private interface BiConsumer<T, U> {
+    public interface BiConsumer<T, U> {
         void accept(T t, U u);
     }
 }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -470,6 +470,14 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         return getUserMediaImpl.getTrack(trackId);
     }
 
+    public VideoTrack createVideoTrack(AbstractVideoCaptureController videoCaptureController) {
+        return getUserMediaImpl.createVideoTrack(videoCaptureController);
+    }
+
+    public void createStream(MediaStreamTrack[] tracks, GetUserMediaImpl.BiConsumer<String, ArrayList<WritableMap>> successCallback) {
+        getUserMediaImpl.createStream(tracks, successCallback);
+    }
+
     /**
      * Turns an "options" <tt>ReadableMap</tt> into a <tt>MediaConstraints</tt> object.
      *

--- a/ios/RCTWebRTC.xcodeproj/project.pbxproj
+++ b/ios/RCTWebRTC.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		4EE3A8CD25B841DD00FAA24A /* ScreenCapturer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScreenCapturer.m; path = RCTWebRTC/ScreenCapturer.m; sourceTree = SOURCE_ROOT; };
 		4EE3A8CE25B841DD00FAA24A /* SocketConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SocketConnection.h; path = RCTWebRTC/SocketConnection.h; sourceTree = SOURCE_ROOT; };
 		A20F721AD842563B66292D5B /* Pods_RCTWebRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RCTWebRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7F99C122938F4E0000A2450 /* WebRTCModule+RTCMediaStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "WebRTCModule+RTCMediaStream.h"; path = "RCTWebRTC/WebRTCModule+RTCMediaStream.h"; sourceTree = SOURCE_ROOT; };
 		DEC96576264176C10052DB35 /* DataChannelWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = DataChannelWrapper.m; path = RCTWebRTC/DataChannelWrapper.m; sourceTree = "<group>"; };
 		DEC96579264176DF0052DB35 /* DataChannelWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DataChannelWrapper.h; path = RCTWebRTC/DataChannelWrapper.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -129,6 +130,7 @@
 				4EE3A8B525B8414A00FAA24A /* WebRTCModule+Permissions.m */,
 				4EE3A8B825B8415900FAA24A /* WebRTCModule+RTCDataChannel.h */,
 				4EE3A8B925B8415900FAA24A /* WebRTCModule+RTCDataChannel.m */,
+				D7F99C122938F4E0000A2450 /* WebRTCModule+RTCMediaStream.h */,
 				4EE3A8BC25B8416500FAA24A /* WebRTCModule+RTCMediaStream.m */,
 				4EE3A8C025B8416F00FAA24A /* WebRTCModule+RTCPeerConnection.h */,
 				4EE3A8BF25B8416F00FAA24A /* WebRTCModule+RTCPeerConnection.m */,

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.h
@@ -1,0 +1,7 @@
+#import "WebRTCModule.h"
+#import "CaptureController.h"
+
+@interface WebRTCModule (RTCMediaStream)
+- (RTCVideoTrack *)createVideoTrackWithCaptureController:(CaptureController * (^)(RTCVideoSource *)) captureControllerCreator;
+- (NSArray *)createMediaStream:(NSArray<RTCMediaStreamTrack *> *)tracks;
+@end

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -10,9 +10,11 @@
 #import <WebRTC/RTCCameraVideoCapturer.h>
 #import <WebRTC/RTCVideoTrack.h>
 #import <WebRTC/RTCMediaConstraints.h>
+#import <WebRTC/RTCMediaStreamTrack.h>
 
 #import "RTCMediaStreamTrack+React.h"
 #import "WebRTCModule+RTCPeerConnection.h"
+#import "WebRTCModule+RTCMediaStream.h"
 
 #import "ScreenCapturer.h"
 #import "ScreenCaptureController.h"
@@ -33,6 +35,75 @@
   RTCAudioTrack *audioTrack
     = [self.peerConnectionFactory audioTrackWithTrackId:trackId];
   return audioTrack;
+}
+
+/**
+ * Initializes a new {@link RTCVideoTrack} with the given capture controller
+ */
+- (RTCVideoTrack *)createVideoTrackWithCaptureController:(CaptureController * (^) (RTCVideoSource *)) captureControllerCreator {
+  RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+
+  NSString *trackUUID = [[NSUUID UUID] UUIDString];
+  RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+  
+  CaptureController * captureController = captureControllerCreator(videoSource);
+  videoTrack.captureController = captureController;
+  [captureController startCapture];
+
+  return videoTrack;
+}
+
+/**
+ * Initializes a new {@link RTCMediaTrack} with the given tracks.
+ *
+ * @return An array with the mediaStreamId in index 0, and track infos in index 1.
+ */
+- (NSArray *)createMediaStream:(NSArray<RTCMediaStreamTrack *> *)tracks {
+  
+  NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
+  RTCMediaStream *mediaStream
+    = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+  NSMutableArray<NSDictionary *> *trackInfos = [NSMutableArray array];
+  
+  for (RTCMediaStreamTrack *track in tracks) {
+    if ([track.kind isEqualToString:@"audio"]) {
+      [mediaStream addAudioTrack:(RTCAudioTrack *)track];
+    } else if([track.kind isEqualToString:@"video"]) {
+      [mediaStream addVideoTrack:(RTCVideoTrack *)track];
+    }
+
+    NSString *trackId = track.trackId;
+
+    self.localTracks[trackId] = track;
+    
+    NSDictionary *settings = @{};
+    if ([track.kind isEqualToString:@"video"]) {
+      RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+      if ([videoTrack.captureController isKindOfClass:[VideoCaptureController class]]){
+        VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
+        AVCaptureDeviceFormat *format = vcc.selectedFormat;
+        CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
+        settings = @{
+          @"height": @(dimensions.height),
+          @"width": @(dimensions.width),
+          @"frameRate": @(3)
+        };
+      }
+    }
+
+    [trackInfos addObject:@{
+                        @"enabled": @(track.isEnabled),
+                        @"id": trackId,
+                        @"kind": track.kind,
+                        @"label": trackId,
+                        @"readyState": @"live",
+                        @"remote": @(NO),
+                        @"settings": settings
+                        }];
+  }
+
+  self.localStreams[mediaStreamId] = mediaStream;
+  return @[ mediaStreamId, trackInfos ];
 }
 
 /**


### PR DESCRIPTION
Addresses #805. Exposes the needed methods to create a video track with a custom capturer.

Note: I was able to get Android working fine. iOS streamed video to remote subscribers fine, but when displaying that same video locally, it only displayed a solid color; not sure where the source of that issue lies.