### PR TITLE
android: fix race condition when disposing tracks

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -192,7 +192,7 @@ public class WebRTCView extends ViewGroup {
                 Log.w(TAG, "No video stream for react tag: " + streamURL);
             }
         }
-        
+
         return videoTrack;
     }
 
@@ -339,14 +339,14 @@ public class WebRTCView extends ViewGroup {
     private void removeRendererFromVideoTrack() {
         if (rendererAttached) {
             if (videoTrack != null) {
-                // XXX If WebRTCModule#mediaStreamTrackRelease has already been
-                // invoked on videoTrack, then it is no longer safe to call removeSink
-                // on the instance, it will throw IllegalStateException.
                 try {
-                    videoTrack.removeSink(surfaceViewRenderer);
+                    ThreadUtils.submitToExecutor(() -> {
+                        videoTrack.removeSink(surfaceViewRenderer);
+                    }).get();
                 } catch (Throwable tr) {
-                    // Releasing streams happens in the WebRTC thread, thus we might (briefly) hold
-                    // a reference to a released stream. Just ignore the error and move on.
+                    // XXX If WebRTCModule#mediaStreamTrackRelease has already been
+                    // invoked on videoTrack, then it is no longer safe to call removeSink
+                    // on the instance, it will throw IllegalStateException.
                 }
             }
 
@@ -548,14 +548,15 @@ public class WebRTCView extends ViewGroup {
                 surfaceViewRendererInstances--;
             }
 
-            // XXX If WebRTCModule#mediaStreamTrackRelease has already been
-            // invoked on videoTrack, then it is no longer safe to call addSink
-            // on the instance, it will throw IllegalStateException.
             try {
-                videoTrack.addSink(surfaceViewRenderer);
+                ThreadUtils.submitToExecutor(() -> {
+                    videoTrack.addSink(surfaceViewRenderer);
+                }).get();
             } catch (Throwable tr) {
-                // Releasing streams happens in the WebRTC thread, thus we might (briefly) hold
-                // a reference to a released stream.
+                // XXX If WebRTCModule#mediaStreamTrackRelease has already been
+                // invoked on videoTrack, then it is no longer safe to call addSink
+                // on the instance, it will throw IllegalStateException.
+
                 Log.e(TAG, "Failed to add renderer", tr);
 
                 surfaceViewRenderer.release();


### PR DESCRIPTION
Make sure add/removeSink operations run in the WebRTC thread, so it's safe to dispose and not get an error when concurrently modifying the sinks container, which happens inside WebRTC.

Fixes: https://github.com/react-native-webrtc/react-native-webrtc/issues/1257