### PR TITLE
fix: camera switch issue in devices using Camera1Enumerator

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -152,7 +152,7 @@ class GetUserMediaImpl {
             }
             WritableMap params = Arguments.createMap();
             params.putString("facing", isFrontFacing ? "front" : "environment");
-            params.putString("deviceId", "" + i);
+            params.putString("deviceId", deviceName);
             params.putString("groupId", "");
             params.putString("label", deviceName);
             params.putString("kind", "videoinput");


### PR DESCRIPTION
When we try to enumerate devices in the mobile devices using `Camera1Enumerator`, the device response returned when used to switch the camera doesn't change the face of the device; rather it mirrors the front-facing camera. On `Camera2Enumerator` devices, it works fine. To address this issue, we made the `deviceId` the same as the `label` of the device. On `Camera2Enumerator`, this wasn't an issue because the deviceId and the label are the same as the index. On `Camera1Enumerator` devices, we do the same thing and this solves the issue.

Pixel 10, Android 12(Camera2Enumerator)
```
{"deviceId": "0", "facing": "environment", "groupId": "", "kind": "videoinput", "label": "0"}
{"deviceId": "1", "facing": "front", "groupId": "", "kind": "videoinput", "label": "1"}
```

Xiaomi Redmi Y2, Android 9(Camera1Enumerator)
```
{"deviceId": "0", "facing": "environment", "groupId": "", "kind": "videoinput", "label": "Camera 0, Facing back, Orientation 90"}
{"deviceId": "1", "facing": "front", "groupId": "", "kind": "videoinput", "label": "Camera 1, Facing front, Orientation 270"}
```