### PR TITLE
fix: remove unncessary break statement

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -146,9 +146,9 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
                 this.isFrontFacing = cameraEnumerator.isFrontFacing(name);
                 return videoCapturer;
             } else {
+                // fallback to facingMode
                 Log.d(TAG, message + " failed");
                 failedDevices.add(name);
-                break; // fallback to facingMode
             }
         }
 


### PR DESCRIPTION
I created a run time crash on java by forgetting to remove the break statement with the for loop removal in #1277. 

Apologies. 