### PR TITLE
android: stop screen capture when media projection is stopped

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
@@ -57,6 +57,7 @@ public class ScreenCaptureController extends AbstractVideoCaptureController {
                 public void onStop() {
                     Log.w(TAG, "Media projection stopped.");
                     orientatationListener.disable();
+                    stopCapture();
                 }
             });
 


### PR DESCRIPTION
`ScreenCapturerAndroid` currently doesn't stop when the MediaProjection is stopped (only stops when `stopCapture` is called). This stops the capturer when that happens so we can release any resources associated with capture.