### PR TITLE
Refactor SDP operations

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -998,20 +998,22 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
                 @Override
                 public void onSetSuccess() {
-                    WritableMap newSdpMap = Arguments.createMap();
-                    WritableMap params = Arguments.createMap();
+                    ThreadUtils.runOnExecutor(() -> {
+                        WritableMap newSdpMap = Arguments.createMap();
+                        WritableMap params = Arguments.createMap();
 
-                    SessionDescription newSdp = peerConnection.getLocalDescription();
-                    // Can happen when doing a rollback.
-                    if (newSdp != null) {
-                        newSdpMap.putString("type", newSdp.type.canonicalForm());
-                        newSdpMap.putString("sdp", newSdp.description);
-                    }
+                        SessionDescription newSdp = peerConnection.getLocalDescription();
+                        // Can happen when doing a rollback.
+                        if (newSdp != null) {
+                            newSdpMap.putString("type", newSdp.type.canonicalForm());
+                            newSdpMap.putString("sdp", newSdp.description);
+                        }
 
-                    params.putMap("sdpInfo", newSdpMap);
-                    params.putArray("transceiversInfo", getTransceiversInfo(peerConnection));
+                        params.putMap("sdpInfo", newSdpMap);
+                        params.putArray("transceiversInfo", getTransceiversInfo(peerConnection));
 
-                    promise.resolve(params);
+                        promise.resolve(params);
+                    });
                 }
 
                 @Override
@@ -1020,7 +1022,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
                 @Override
                 public void onSetFailure(String s) {
-                    promise.reject("E_OPERATION_ERROR", s);
+                    ThreadUtils.runOnExecutor(() -> {
+                        promise.reject("E_OPERATION_ERROR", s);
+                    });
                 }
             };
 
@@ -1068,32 +1072,34 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
                 @Override
                 public void onSetSuccess() {
-                    WritableMap newSdpMap = Arguments.createMap();
-                    WritableMap params = Arguments.createMap();
+                    ThreadUtils.runOnExecutor(() -> {
+                        WritableMap newSdpMap = Arguments.createMap();
+                        WritableMap params = Arguments.createMap();
 
-                    SessionDescription newSdp = peerConnection.getRemoteDescription();
-                    // Be defensive for the rollback cases.
-                    if (newSdp != null) {
-                        newSdpMap.putString("type", newSdp.type.canonicalForm());
-                        newSdpMap.putString("sdp", newSdp.description);
-                    }
-
-                    params.putArray("transceiversInfo", getTransceiversInfo(peerConnection));
-                    params.putMap("sdpInfo", newSdpMap);
-
-                    WritableArray newTransceivers = Arguments.createArray();
-                    for(RtpTransceiver transceiver: peerConnection.getTransceivers()) {
-                        if(!receiversIds.contains(transceiver.getReceiver().id())) {
-                            WritableMap newTransceiver = Arguments.createMap();
-                            newTransceiver.putInt("transceiverOrder", pco.getNextTransceiverId());
-                            newTransceiver.putMap("transceiver", SerializeUtils.serializeTransceiver(id, transceiver));
-                            newTransceivers.pushMap(newTransceiver);
+                        SessionDescription newSdp = peerConnection.getRemoteDescription();
+                        // Be defensive for the rollback cases.
+                        if (newSdp != null) {
+                            newSdpMap.putString("type", newSdp.type.canonicalForm());
+                            newSdpMap.putString("sdp", newSdp.description);
                         }
-                    }
 
-                    params.putArray("newTransceivers", newTransceivers);
+                        params.putArray("transceiversInfo", getTransceiversInfo(peerConnection));
+                        params.putMap("sdpInfo", newSdpMap);
 
-                    promise.resolve(params);
+                        WritableArray newTransceivers = Arguments.createArray();
+                        for(RtpTransceiver transceiver: peerConnection.getTransceivers()) {
+                            if(!receiversIds.contains(transceiver.getReceiver().id())) {
+                                WritableMap newTransceiver = Arguments.createMap();
+                                newTransceiver.putInt("transceiverOrder", pco.getNextTransceiverId());
+                                newTransceiver.putMap("transceiver", SerializeUtils.serializeTransceiver(id, transceiver));
+                                newTransceivers.pushMap(newTransceiver);
+                            }
+                        }
+
+                        params.putArray("newTransceivers", newTransceivers);
+
+                        promise.resolve(params);
+                    });
                 }
 
                 @Override
@@ -1102,7 +1108,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
                 @Override
                 public void onSetFailure(String s) {
-                    promise.reject("E_OPERATION_ERROR", s);
+                    ThreadUtils.runOnExecutor(() -> {
+                        promise.reject("E_OPERATION_ERROR", s);
+                    });
                 }
             };
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -211,6 +211,7 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(nonnull NSNumber *)objectID
   __weak RTCPeerConnection *weakPc = peerConnection;
 
   RTCSetSessionDescriptionCompletionHandler handler = ^(NSError *error) {
+    dispatch_async(self.workerQueue, ^{
       if (error) {
           reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
       } else {
@@ -227,6 +228,7 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(nonnull NSNumber *)objectID
         };
         resolve(data);
       }
+    });
   };
 
   if (desc == nil) {
@@ -255,6 +257,7 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(nonnull NSNumber *)objectI
   __weak RTCPeerConnection *weakPc = peerConnection;
 
   RTCSetSessionDescriptionCompletionHandler handler = ^(NSError *error) {
+    dispatch_async(self.workerQueue, ^{
       if (error) {
           reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
       } else {
@@ -281,6 +284,7 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(nonnull NSNumber *)objectI
         };
         resolve(data);
       }
+    });
   };
 
   [peerConnection setRemoteDescription:desc completionHandler:handler];


### PR DESCRIPTION
Make sure we handle the async result and move to the WebRTC thread
before sending events to JS.

This also fixes some underlying timing issues: the SDP was not up to
date inside the `track` event, which may have created some subtle
shenanigans for some.

This should also fix some crashes we have been seeing when getting the
native transceiver list, since the operation will have been completed
by the time we get it again.

Ref: https://github.com/react-native-webrtc/react-native-webrtc/issues/1284
Ref: https://github.com/react-native-webrtc/react-native-webrtc/issues/1289