### PR TITLE
pc: refactor PeerConnection close

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -74,8 +74,11 @@ class PeerConnectionObserver implements PeerConnection.Observer {
     void close() {
         Log.d(TAG, "PeerConnection.close() for " + id);
 
-        // Close the PeerConnection first to stop any events.
         peerConnection.close();
+    }
+
+    void dispose() {
+        Log.d(TAG, "PeerConnection.dispose() for " + id);
 
         // Remove video track adapters
         for (MediaStreamTrack track : this.remoteTracks.values()) {
@@ -87,7 +90,6 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         // Remove DataChannel observers
         for (DataChannelWrapper dcw : dataChannels.values()) {
             DataChannel dataChannel = dcw.getDataChannel();
-            dataChannel.close();
             dataChannel.unregisterObserver();
         }
 
@@ -100,7 +102,6 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         remoteTracks.clear();
         dataChannels.clear();
     }
-
 
     public synchronized int getNextTransceiverId() {
         return transceiverNextId++;

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1265,10 +1265,21 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
             if (pco == null || pco.getPeerConnection() == null) {
                 Log.d(TAG, "peerConnectionClose() peerConnection is null");
-            } else {
-                pco.close();
-                mPeerConnectionObservers.remove(id);
+                return;
             }
+            pco.close();
+        });
+    }
+
+    @ReactMethod
+    public void peerConnectionDispose(int id) {
+        ThreadUtils.runOnExecutor(() -> {
+            PeerConnectionObserver pco = mPeerConnectionObservers.get(id);
+            if (pco == null || pco.getPeerConnection() == null) {
+                Log.d(TAG, "peerConnectionDispose() peerConnection is null");
+            }
+            pco.dispose();
+            mPeerConnectionObservers.remove(id);
         });
     }
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -312,6 +312,16 @@ RCT_EXPORT_METHOD(peerConnectionClose:(nonnull NSNumber *)objectID)
     return;
   }
 
+  [peerConnection close];
+}
+
+RCT_EXPORT_METHOD(peerConnectionDispose:(nonnull NSNumber *)objectID)
+{
+  RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+  if (!peerConnection) {
+    return;
+  }
+
   // Remove video track adapters
   for (NSString *key in peerConnection.remoteTracks.allKeys) {
       RTCMediaStreamTrack *track = peerConnection.remoteTracks[key];
@@ -319,8 +329,6 @@ RCT_EXPORT_METHOD(peerConnectionClose:(nonnull NSNumber *)objectID)
         [peerConnection removeVideoTrackAdapter: (RTCVideoTrack*) track];
       }
   }
-
-  [peerConnection close];
 
   // Clean up peerConnection's streams and tracks
   [peerConnection.remoteStreams removeAllObjects];


### PR DESCRIPTION
First trigger the PC close(), then wait until the connection state goes to "closed" and dispose it. This guarantees that all state change listeners and data channel events fire before teh actual closure.