### PR TITLE
Turn on NWPathMonitor field trial to fix dual sim connectivity

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -5,6 +5,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTUtils.h>
+#import <WebRTC/RTCFieldTrials.h>
 
 #import "WebRTCModule+RTCPeerConnection.h"
 #import "WebRTCModule.h"
@@ -42,6 +43,12 @@
                         decoderFactory:(nullable id<RTCVideoDecoderFactory>)decoderFactory {
     self = [super init];
     if (self) {
+
+        // Fix for dual-sim connectivity
+        // https://bugs.chromium.org/p/webrtc/issues/detail?id=10966
+        NSDictionary *fieldTrials = @{kRTCFieldTrialUseNWPathMonitor : kRTCFieldTrialEnabledValue};
+        RTCInitFieldTrialDictionary(fieldTrials);
+
         if (encoderFactory == nil) {
             encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
         }


### PR DESCRIPTION
Context: https://bugs.chromium.org/p/webrtc/issues/detail?id=10966

The default ICE network policy doesn't work with iPhones that have dual sims. There's a field trial to fix this that was created in 2020 but hasn't been turned on default yet. Seems like others have turned it on with no issues, and verified that this works in our project.

Not sure if this is the best way to handle this though; only one field trial dictionary is in effect at any time, so this would overwrite any user-defined field trials. Should this just be an iOS installation instruction instead?