### PR TITLE
Updated Basic Usage and Call Guide docs

### DIFF
--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -268,7 +268,7 @@ try {
 	const offerDescription = new RTCSessionDescription( offerDescription );
 	await peerConnection.setRemoteDescription( offerDescription );
 
-	const answerDescription = await peerConnection.createAnswer( sessionConstraints );
+	const answerDescription = await peerConnection.createAnswer();
 	await peerConnection.setLocalDescription( answerDescription );
 
 	// Send the answerDescription back as a response to the offerDescription.

--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -118,7 +118,7 @@ Cycling all of the tracks and stopping them is more than enough to clean up afte
 You won't usually need to do this for remote tracks, only local.  
 
 ```javascript
-localMediaStream.getTracks().map(
+localMediaStream.getTracks().forEach(
 	track => track.stop()
 );
 
@@ -155,8 +155,8 @@ peerConnection.addEventListener( 'iceconnectionstatechange', event => {} );
 peerConnection.addEventListener( 'icegatheringstatechange', event => {} );
 peerConnection.addEventListener( 'negotiationneeded', event => {} );
 peerConnection.addEventListener( 'signalingstatechange', event => {} );
-peerConnection.addEventListener( 'addstream', event => {} );
-peerConnection.addEventListener( 'removestream', event => {} );
+peerConnection.addEventListener( 'track', event => {} );
+peerConnection.addEventListener( 'removetrack', event => {} );
 ```
 
 ## Destroying the Peer Connection
@@ -165,7 +165,6 @@ When ending a call you should always make sure to dispose of everything ready fo
 The following should dispose of everything related to the peer connection.  
 
 ```javascript
-peerConnection._unregisterEvents();
 peerConnection.close();
 peerConnection = null;
 ```
@@ -176,7 +175,9 @@ After using one of the media functions above you can then add the media stream t
 The negotiation needed event will be triggered on the peer connection afterwords.  
 
 ```javascript
-peerConnection.addStream( localMediaStream );
+localMediaStream.getTracks().forEach( 
+	track => peerConnection.addTrack( track, localMediaStream );
+);
 ```
 
 ## Creating a Data Channel

--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -156,7 +156,6 @@ peerConnection.addEventListener( 'icegatheringstatechange', event => {} );
 peerConnection.addEventListener( 'negotiationneeded', event => {} );
 peerConnection.addEventListener( 'signalingstatechange', event => {} );
 peerConnection.addEventListener( 'track', event => {} );
-peerConnection.addEventListener( 'removetrack', event => {} );
 ```
 
 ## Destroying the Peer Connection

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -116,9 +116,8 @@ peerConnection.addEventListener( 'signalingstatechange', event => {
 peerConnection.addEventListener( 'track', event => {
 	// Grab the remote stream from the connected participant.
 	const connection = event.target;
-	const stream = connection?._remoteStreams.values().next().value;
-    remoteMediaStream = new MediaStream(stream);
-);
+	const stream = connection._remoteStreams.values().next().value;
+    remoteMediaStream = new MediaStream( stream );
 } );
 
 // Add our stream to the peer connection.

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -117,7 +117,7 @@ peerConnection.addEventListener( 'track', event => {
 	// Grab the remote stream from the connected participant.
 	const connection = event.target;
 	const stream = connection._remoteStreams.values().next().value;
-    remoteMediaStream = new MediaStream( stream );
+	remoteMediaStream = new MediaStream( stream );
 } );
 
 // Add our stream to the peer connection.

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -30,6 +30,7 @@ let mediaConstraints = {
 };
 
 let localMediaStream;
+let remoteMediaStream;
 let isVoiceOnly = false;
 
 try {

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -205,7 +205,7 @@ try {
 	const offerDescription = new RTCSessionDescription( offerDescription );
 	await peerConnection.setRemoteDescription( offerDescription );
 
-	const answerDescription = await peerConnection.createAnswer( sessionConstraints );
+	const answerDescription = await peerConnection.createAnswer();
 	await peerConnection.setLocalDescription( answerDescription );
 
 	// Here is a good place to process candidates.

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -113,13 +113,18 @@ peerConnection.addEventListener( 'signalingstatechange', event => {
 	};
 } );
 
-peerConnection.addEventListener( 'addstream', event => {
+peerConnection.addEventListener( 'track', event => {
 	// Grab the remote stream from the connected participant.
-	remoteMediaStream = event.stream;
+	const connection = event.target;
+	const stream = connection?._remoteStreams.values().next().value;
+    remoteMediaStream = new MediaStream(stream);
+);
 } );
 
 // Add our stream to the peer connection.
-peerConnection.addStream( localMediaStream );
+localMediaStream.getTracks().forEach( 
+	track => peerConnection.addTrack( track, localMediaStream );
+);
 ```
 
 ## Step 3 - Signal that you're starting a call

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -114,10 +114,9 @@ peerConnection.addEventListener( 'signalingstatechange', event => {
 } );
 
 peerConnection.addEventListener( 'track', event => {
-	// Grab the remote stream from the connected participant.
-	const connection = event.target;
-	const stream = connection._remoteStreams.values().next().value;
-	remoteMediaStream = new MediaStream( stream );
+	// Grab the remote track from the connected participant.
+	remoteMediaStream = remoteMediaStream || new MediaStream();
+	remoteMediaStream.addTrack( event.track, remoteMediaStream );
 } );
 
 // Add our stream to the peer connection.


### PR DESCRIPTION
As stream api was deprecated and replaced by tracks, I updated docs to correspond actual code. 
Also `RTCPeerConnection::createAnswer` don't have any params anymore, so removed this from docs as well.