### PR TITLE
Quick null check for both ios and android.

### DIFF
--- a/src/RTCRtpTransceiver.ts
+++ b/src/RTCRtpTransceiver.ts
@@ -5,7 +5,6 @@ import RTCRtpSender from './RTCRtpSender';
 
 const { WebRTCModule } = NativeModules;
 
-
 export default class RTCRtpTransceiver {
     _peerConnectionId: number;
     _sender: RTCRtpSender;
@@ -52,7 +51,7 @@ export default class RTCRtpTransceiver {
         }
 
         if (this._stopped) {
-            throw Error('Transceiver Stopped');
+            throw new Error('Transceiver Stopped');
         }
 
         if (this._direction === val) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
+import { NativeModules, Platform } from 'react-native';
+const { WebRTCModule } = NativeModules;
+
+if (WebRTCModule === null) {
+    throw new Error(`WebRTC native module not found.\n${Platform.OS === 'ios' ?
+        'Try executing the "pod install" command inside your projects ios folder.' :
+        'Try executing the "npm install" command inside your projects folder.'
+    }`);
+}
+
 import { setupNativeEvents } from './EventEmitter';
 import Logger from './Logger';
 import mediaDevices from './MediaDevices';


### PR DESCRIPTION
Won't fix [this](https://github.com/react-native-webrtc/react-native-webrtc/issues/1346) issue but will make developers aware that they will need to run pod install or npm install as it would appear some linking commands don't always execute properly when adding packages to your project.

Not actually sure if that is intentional or not.
Also would it be worth mentioning anything about alternative package managers like yarn? 