### PR TITLE
android: bump API level to 24, aka Android 7

### DIFF
--- a/Documentation/AndroidInstallation.md
+++ b/Documentation/AndroidInstallation.md
@@ -4,6 +4,8 @@ Starting with React Native 0.60 due to a new auto linking feature you no longer 
 
 See a sample app in the `examples/GumTestApp` directory.  
 
+**IMPORTANT:** Android API level >= 24 are supported.
+
 ## Declaring Permissions
 
 In `android/app/src/main/AndroidManifest.xml` add the following permissions before the `<application>` section.  

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    compileSdkVersion safeExtGet('compileSdkVersion', 24)
     buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 19)
-        targetSdkVersion safeExtGet('targetSdkVersion', 23)
+        minSdkVersion safeExtGet('minSdkVersion', 24)
+        targetSdkVersion safeExtGet('targetSdkVersion', 24)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
We have already de-facto done it since some of the code after the migration to UP requires API level 24.