### PR TITLE
api: refactor nonstandard createOffer options

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -871,7 +871,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void peerConnectionCreateOffer(int id, ReadableMap options, Promise promise) {
+    public void peerConnectionCreateOffer(int id, Promise promise) {
         ThreadUtils.runOnExecutor(() -> {
             PeerConnection peerConnection = getPeerConnection(id);
 
@@ -910,7 +910,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 public void onSetSuccess() {}
             };
 
-            peerConnection.createOffer(observer, constraintsForOptions(options));
+            peerConnection.createOffer(observer, new MediaConstraints());
         });
     }
 
@@ -954,7 +954,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 public void onSetSuccess() {}
             };
 
-            peerConnection.createAnswer(observer, constraintsForOptions(options));
+            peerConnection.createAnswer(observer, new MediaConstraints());
         });
     }
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -107,8 +107,7 @@ RCT_EXPORT_METHOD(peerConnectionSetConfiguration
 }
 
 RCT_EXPORT_METHOD(peerConnectionCreateOffer
-                  : (nonnull NSNumber *)objectID options
-                  : (NSDictionary *)options resolver
+                  : (nonnull NSNumber *)objectID resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
     RTCPeerConnection *peerConnection = self.peerConnections[objectID];
@@ -117,7 +116,7 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer
         return;
     }
 
-    RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:options
+    RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil
                                                                              optionalConstraints:nil];
 
     RTCCreateSessionDescriptionCompletionHandler handler = ^(RTCSessionDescription *desc, NSError *error) {
@@ -142,8 +141,7 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer
 }
 
 RCT_EXPORT_METHOD(peerConnectionCreateAnswer
-                  : (nonnull NSNumber *)objectID options
-                  : (NSDictionary *)options resolver
+                  : (nonnull NSNumber *)objectID resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
     RTCPeerConnection *peerConnection = self.peerConnections[objectID];
@@ -152,7 +150,7 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer
         return;
     }
 
-    RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:options
+    RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil
                                                                              optionalConstraints:nil];
 
     RTCCreateSessionDescriptionCompletionHandler handler = ^(RTCSessionDescription *desc, NSError *error) {

--- a/src/RTCUtil.ts
+++ b/src/RTCUtil.ts
@@ -12,13 +12,6 @@ const FACING_MODES = [ 'user', 'environment' ];
 
 const ASPECT_RATIO = 16 / 9;
 
-const STANDARD_OFFER_OPTIONS = {
-    icerestart: 'IceRestart',
-    offertoreceiveaudio: 'OfferToReceiveAudio',
-    offertoreceivevideo: 'OfferToReceiveVideo',
-    voiceactivitydetection: 'VoiceActivityDetection'
-};
-
 const SDP_TYPES = [
     'offer',
     'pranswer',
@@ -149,32 +142,6 @@ export function deepClone<T>(obj: T): T {
  */
 export function isSdpTypeValid(type: string): boolean {
     return SDP_TYPES.includes(type);
-}
-
-/**
- * Normalize options passed to createOffer().
- *
- * @param options - user supplied options
- * @return Normalized options
- */
-export function normalizeOfferOptions(options: object = {}): object {
-    const newOptions = {};
-
-    if (!options) {
-        return newOptions;
-    }
-
-    // Convert standard options into WebRTC internal constant names.
-    // See: https://github.com/jitsi/webrtc/blob/0cd6ce4de669bed94ba47b88cb71b9be0341bb81/sdk/media_constraints.cc#L113
-    for (const [ key, value ] of Object.entries(options)) {
-        const newKey = STANDARD_OFFER_OPTIONS[key.toLowerCase()];
-
-        if (newKey) {
-            newOptions[newKey] = String(Boolean(value));
-        }
-    }
-
-    return newOptions;
 }
 
 /**


### PR DESCRIPTION
~~They don't work properly with transceivers and they are deprecated anyway.~~

Keep only the legacy ones mentioned in 4.4.3.2 but implement them in JS
since the native ones seem to not function correctly in certain
circumstances.

Closes: https://github.com/react-native-webrtc/react-native-webrtc/issues/1353