### PR TITLE
gum: don't pass any track label

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -321,7 +321,6 @@ class GetUserMediaImpl {
             trackInfo.putBoolean("enabled", track.enabled());
             trackInfo.putString("id", trackId);
             trackInfo.putString("kind", track.kind());
-            trackInfo.putString("label", trackId);
             trackInfo.putString("readyState", track.state().toString().toLowerCase());
             trackInfo.putBoolean("remote", false);
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -83,7 +83,6 @@
             @"enabled" : @(track.isEnabled),
             @"id" : trackId,
             @"kind" : track.kind,
-            @"label" : trackId,
             @"readyState" : @"live",
             @"remote" : @(NO),
             @"settings" : settings
@@ -155,7 +154,6 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
         @"enabled" : @(videoTrack.isEnabled),
         @"id" : videoTrack.trackId,
         @"kind" : videoTrack.kind,
-        @"label" : videoTrack.trackId,
         @"readyState" : @"live",
         @"remote" : @(NO)
     };
@@ -225,7 +223,6 @@ RCT_EXPORT_METHOD(getUserMedia
             @"enabled" : @(track.isEnabled),
             @"id" : trackId,
             @"kind" : track.kind,
-            @"label" : trackId,
             @"readyState" : @"live",
             @"remote" : @(NO),
             @"settings" : settings


### PR DESCRIPTION
We ignore them in the JS layer. It just defaults to ''.