### PR TITLE
pc: fix handling legacy options in createOffer

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -96,10 +96,26 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
         const {
             sdpInfo,
+            newTransceivers,
             transceiversInfo
         } = await WebRTCModule.peerConnectionCreateOffer(this._pcId, RTCUtil.normalizeOfferOptions(options));
 
         log.debug(`${this._pcId} createOffer OK`);
+
+        newTransceivers?.forEach(t => {
+            const { transceiverOrder, transceiver } = t;
+            const newSender = new RTCRtpSender({ ...transceiver.sender, track: null });
+            const remoteTrack
+                = transceiver.receiver.track ? new MediaStreamTrack(transceiver.receiver.track) : null;
+            const newReceiver = new RTCRtpReceiver({ ...transceiver.receiver, track: remoteTrack });
+            const newTransceiver = new RTCRtpTransceiver({
+                ...transceiver,
+                sender: newSender,
+                receiver: newReceiver,
+            });
+
+            this._insertTransceiverSorted(transceiverOrder, newTransceiver);
+        });
 
         this._updateTransceivers(transceiversInfo);
 

--- a/src/RTCRtpTransceiver.ts
+++ b/src/RTCRtpTransceiver.ts
@@ -25,9 +25,9 @@ export default class RTCRtpTransceiver {
         receiver: RTCRtpReceiver,
     }) {
         this._peerConnectionId = args.peerConnectionId;
-        this._mid = args.mid ? args.mid : null;
+        this._mid = args.mid ?? null;
         this._direction = args.direction;
-        this._currentDirection = args.currentDirection;
+        this._currentDirection = args.currentDirection ?? null;
         this._stopped = Boolean(args.isStopped);
         this._sender = args.sender;
         this._receiver = args.receiver;


### PR DESCRIPTION
They may create new transceivers, so make sure we create the corresponding JS objects.

Fixes: https://github.com/react-native-webrtc/react-native-webrtc/issues/1353
Ref: https://github.com/react-native-webrtc/react-native-webrtc/pull/1375