### PR TITLE
log: only enable the rn-webrtc logger automatically

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,7 @@ import RTCSessionDescription from './RTCSessionDescription';
 import RTCView from './RTCView';
 import ScreenCapturePickerView from './ScreenCapturePickerView';
 
-Logger.enable('*');
-// Logger.enable(`*,-${Logger.ROOT_PREFIX}:*:DEBUG`);
+Logger.enable(`${Logger.ROOT_PREFIX}:*`);
 
 // Add listeners for the native events early, since they are added asynchronously.
 setupNativeEvents();


### PR DESCRIPTION
Fixes: https://github.com/react-native-webrtc/react-native-webrtc/issues/1371