### PR TITLE
Add pending and current descriptions

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -502,9 +502,27 @@ class PeerConnectionObserver implements PeerConnection.Observer {
     @Override
     public void onSignalingChange(PeerConnection.SignalingState signalingState) {
         ThreadUtils.runOnExecutor(() -> {
+            WritableMap newLocalSdpMap = Arguments.createMap();
+            WritableMap newRemoteSdpMap = Arguments.createMap();
+            SessionDescription newLocalSdp = peerConnection.getLocalDescription();
+            SessionDescription newRemoteSdp = peerConnection.getRemoteDescription();
+
+            if (newLocalSdp != null) {
+                newLocalSdpMap.putString("type", newLocalSdp.type.canonicalForm());
+                newLocalSdpMap.putString("sdp", newLocalSdp.description);
+            }
+
+            if (newRemoteSdp != null) {
+                newRemoteSdpMap.putString("type", newRemoteSdp.type.canonicalForm());
+                newRemoteSdpMap.putString("sdp", newRemoteSdp.description);
+            }
+
             WritableMap params = Arguments.createMap();
             params.putInt("pcId", id);
             params.putString("signalingState", signalingStateString(signalingState));
+            params.putMap("localSdp", newLocalSdpMap);
+            params.putMap("remoteSdp", newRemoteSdpMap);
+
             webRTCModule.sendEvent("peerConnectionSignalingStateChanged", params);
         });
     }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1006,17 +1006,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onSetSuccess() {
                     ThreadUtils.runOnExecutor(() -> {
-                        WritableMap newSdpMap = Arguments.createMap();
                         WritableMap params = Arguments.createMap();
-
-                        SessionDescription newSdp = peerConnection.getLocalDescription();
-                        // Can happen when doing a rollback.
-                        if (newSdp != null) {
-                            newSdpMap.putString("type", newSdp.type.canonicalForm());
-                            newSdpMap.putString("sdp", newSdp.description);
-                        }
-
-                        params.putMap("sdpInfo", newSdpMap);
                         params.putArray("transceiversInfo", getTransceiversInfo(peerConnection));
 
                         promise.resolve(params);
@@ -1071,18 +1061,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onSetSuccess() {
                     ThreadUtils.runOnExecutor(() -> {
-                        WritableMap newSdpMap = Arguments.createMap();
                         WritableMap params = Arguments.createMap();
-
-                        SessionDescription newSdp = peerConnection.getRemoteDescription();
-                        // Be defensive for the rollback cases.
-                        if (newSdp != null) {
-                            newSdpMap.putString("type", newSdp.type.canonicalForm());
-                            newSdpMap.putString("sdp", newSdp.description);
-                        }
-
                         params.putArray("transceiversInfo", getTransceiversInfo(peerConnection));
-                        params.putMap("sdpInfo", newSdpMap);
 
                         WritableArray newTransceivers = Arguments.createArray();
                         for (RtpTransceiver transceiver : peerConnection.getTransceivers()) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -202,14 +202,7 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription
             if (error) {
                 reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
             } else {
-                NSMutableDictionary *sdpInfo = [NSMutableDictionary new];
-                RTCSessionDescription *localDesc = peerConnection.localDescription;
-                if (localDesc) {
-                    sdpInfo[@"type"] = [RTCSessionDescription stringForType:localDesc.type];
-                    sdpInfo[@"sdp"] = localDesc.sdp;
-                }
                 id data = @{
-                    @"sdpInfo" : sdpInfo,
                     @"transceiversInfo" :
                         [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection]
                 };
@@ -257,14 +250,7 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription
                     }
                 }
 
-                NSMutableDictionary *sdpInfo = [NSMutableDictionary new];
-                RTCSessionDescription *remoteDesc = peerConnection.remoteDescription;
-                if (remoteDesc) {
-                    sdpInfo[@"type"] = [RTCSessionDescription stringForType:remoteDesc.type];
-                    sdpInfo[@"sdp"] = remoteDesc.sdp;
-                }
                 id data = @{
-                    @"sdpInfo" : sdpInfo,
                     @"transceiversInfo" :
                         [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection],
                     @"newTransceivers" : newTransceivers

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -732,10 +732,29 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
 
 - (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeSignalingState:(RTCSignalingState)newState {
     dispatch_async(self.workerQueue, ^{
+        id newLocalSdp = @{};
+        id newRemoteSdp = @{};
+        
+        if (peerConnection.localDescription) {
+            newLocalSdp = @{
+                @"type" : [RTCSessionDescription stringForType:peerConnection.localDescription.type],
+                @"sdp" : peerConnection.localDescription.sdp
+            };
+        }
+        
+        if (peerConnection.remoteDescription) {
+            newRemoteSdp = @{
+                @"type" : [RTCSessionDescription stringForType:peerConnection.remoteDescription.type],
+                @"sdp" : peerConnection.remoteDescription.sdp
+            };
+        }
+        
         [self sendEventWithName:kEventPeerConnectionSignalingStateChanged
                            body:@{
                                @"pcId" : peerConnection.reactTag,
-                               @"signalingState" : [self stringForSignalingState:newState]
+                               @"signalingState" : [self stringForSignalingState:newState],
+                               @"localSdp": newLocalSdp,
+                               @"remoteSdp": newRemoteSdp
                            }];
     });
 }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -720,27 +720,27 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     dispatch_async(self.workerQueue, ^{
         id newLocalSdp = @{};
         id newRemoteSdp = @{};
-        
+
         if (peerConnection.localDescription) {
             newLocalSdp = @{
                 @"type" : [RTCSessionDescription stringForType:peerConnection.localDescription.type],
                 @"sdp" : peerConnection.localDescription.sdp
             };
         }
-        
+
         if (peerConnection.remoteDescription) {
             newRemoteSdp = @{
                 @"type" : [RTCSessionDescription stringForType:peerConnection.remoteDescription.type],
                 @"sdp" : peerConnection.remoteDescription.sdp
             };
         }
-        
+
         [self sendEventWithName:kEventPeerConnectionSignalingStateChanged
                            body:@{
                                @"pcId" : peerConnection.reactTag,
                                @"signalingState" : [self stringForSignalingState:newState],
-                               @"localSdp": newLocalSdp,
-                               @"remoteSdp": newRemoteSdp
+                               @"localSdp" : newLocalSdp,
+                               @"remoteSdp" : newRemoteSdp
                            }];
     });
 }

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -183,23 +183,7 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
             desc = null;
         }
 
-        const {
-            sdpInfo,
-            transceiversInfo
-        } = await WebRTCModule.peerConnectionSetLocalDescription(this._pcId, desc);
-
-        if (sdpInfo.type && sdpInfo.sdp) {
-            if (sdpInfo.type === 'answer') {
-                this._currentLocalDescription = new RTCSessionDescription(sdpInfo);
-                this._pendingLocalDescription = null;
-            } else {
-                this._currentLocalDescription = null;
-                this._pendingLocalDescription = new RTCSessionDescription(sdpInfo);
-            }
-        } else {
-            this._currentLocalDescription = null;
-            this._pendingLocalDescription = null;
-        }
+        const { transceiversInfo } = await WebRTCModule.peerConnectionSetLocalDescription(this._pcId, desc);
 
         this._updateTransceivers(transceiversInfo, /* removeStopped */ desc?.type === 'answer');
 
@@ -223,23 +207,9 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
         }
 
         const {
-            sdpInfo,
             newTransceivers,
             transceiversInfo
         } = await WebRTCModule.peerConnectionSetRemoteDescription(this._pcId, desc);
-
-        if (sdpInfo.type && sdpInfo.sdp) {
-            if (sdpInfo.type === 'answer') {
-                this._currentRemoteDescription = new RTCSessionDescription(sdpInfo);
-                this._pendingRemoteDescription = null;
-            } else {
-                this._currentRemoteDescription = null;
-                this._pendingRemoteDescription = new RTCSessionDescription(sdpInfo);
-            }
-        } else {
-            this._currentRemoteDescription = null;
-            this._pendingRemoteDescription = null;
-        }
 
         newTransceivers?.forEach(t => {
             const { transceiverOrder, transceiver } = t;


### PR DESCRIPTION
This PR fixes getting `RTCPeerConnection.localDescription` and `RTCPeerConnection.remoteDescription` according to WebRTC docs:

> On a more fundamental level, the returned value is the value of [RTCPeerConnection.pendingLocalDescription](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/pendingLocalDescription) if that property isn't null; otherwise, the value of [RTCPeerConnection.currentLocalDescription](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/currentLocalDescription) is returned. See [Pending and current descriptions](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Connectivity#pending_and_current_descriptions) in the WebRTC Connectivity page for details on this algorithm and why it's used.