### PR TITLE
Add type to event in RTCPeerConnection and RTC DataChannel

### DIFF
--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -1,22 +1,22 @@
 
-import EventTarget, { defineCustomEventTarget } from 'event-target-shim';
+import EventTarget from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import MediaStreamTrack from './MediaStreamTrack';
-import MediaStreamTrackEvent from "./MediaStreamTrackEvent"
-
+import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import { uniqueID } from './RTCUtil';
 
 const { WebRTCModule } = NativeModules;
 
 const MEDIA_STREAM_EVENTS = [ 'active', 'inactive', 'addtrack', 'removetrack' ];
+
 type MediaStreamEventMap = {
-    active: MediaStreamTrackEvent<"active">
-    inactive: MediaStreamTrackEvent<"inactive">
-    addtrack: MediaStreamTrackEvent<"addtrack">
-    removetrack: MediaStreamTrackEvent<"removetrack">
+    active: MediaStreamTrackEvent<'active'>
+    inactive: MediaStreamTrackEvent<'inactive'>
+    addtrack: MediaStreamTrackEvent<'addtrack'>
+    removetrack: MediaStreamTrackEvent<'removetrack'>
   }
-  
+
 export default class MediaStream extends EventTarget<MediaStreamEventMap> {
     _tracks: MediaStreamTrack[] = [];
 

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -8,8 +8,6 @@ import { uniqueID } from './RTCUtil';
 
 const { WebRTCModule } = NativeModules;
 
-const MEDIA_STREAM_EVENTS = [ 'active', 'inactive', 'addtrack', 'removetrack' ];
-
 type MediaStreamEventMap = {
     active: MediaStreamTrackEvent<'active'>
     inactive: MediaStreamTrackEvent<'inactive'>

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -3,12 +3,20 @@ import { defineCustomEventTarget } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import MediaStreamTrack from './MediaStreamTrack';
+import MediaStreamTrackEvent from "./MediaStreamTrackEvent"
+
 import { uniqueID } from './RTCUtil';
 
 const { WebRTCModule } = NativeModules;
 
 const MEDIA_STREAM_EVENTS = [ 'active', 'inactive', 'addtrack', 'removetrack' ];
-
+type MediaStreamEventMap = {
+    active: MediaStreamTrackEvent<"active">
+    inactive: MediaStreamTrackEvent<"inactive">
+    addtrack: MediaStreamTrackEvent<"addtrack">
+    removetrack: MediaStreamTrackEvent<"removetrack">
+  }
+  
 export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM_EVENTS) {
     _tracks: MediaStreamTrack[] = [];
 

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -1,5 +1,5 @@
 
-import { defineCustomEventTarget } from 'event-target-shim';
+import EventTarget, { defineCustomEventTarget } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import MediaStreamTrack from './MediaStreamTrack';
@@ -17,7 +17,7 @@ type MediaStreamEventMap = {
     removetrack: MediaStreamTrackEvent<"removetrack">
   }
   
-export default class MediaStream extends defineCustomEventTarget(...MEDIA_STREAM_EVENTS) {
+export default class MediaStream extends EventTarget<MediaStreamEventMap> {
     _tracks: MediaStreamTrack[] = [];
 
     _id: string;

--- a/src/MediaStreamTrackEvent.ts
+++ b/src/MediaStreamTrackEvent.ts
@@ -1,11 +1,14 @@
-
+import { Event } from "event-target-shim"
 import type MediaStreamTrack from './MediaStreamTrack';
 
-export default class MediaStreamTrackEvent {
-    type: string;
+interface IMediaStreamTrackEventInitDict extends Event.EventInit {
+  track: MediaStreamTrack;
+}
+
+export default class MediaStreamTrackEvent<TEventType extends string = string> extends Event<TEventType> {
     track: MediaStreamTrack;
-    constructor(type, eventInitDict: { track: MediaStreamTrack }) {
-        this.type = type.toString();
+    constructor(type, eventInitDict: IMediaStreamTrackEventInitDict) {
+        super(type, eventInitDict);
         this.track = eventInitDict.track;
     }
 }

--- a/src/MediaStreamTrackEvent.ts
+++ b/src/MediaStreamTrackEvent.ts
@@ -1,4 +1,5 @@
-import { Event } from "event-target-shim"
+import { Event } from 'event-target-shim';
+
 import type MediaStreamTrack from './MediaStreamTrack';
 
 interface IMediaStreamTrackEventInitDict extends Event.EventInit {

--- a/src/MediaStreamTrackEvent.ts
+++ b/src/MediaStreamTrackEvent.ts
@@ -8,7 +8,15 @@ interface IMediaStreamTrackEventInitDict extends Event.EventInit {
   track: MediaStreamTrack;
 }
 
+/**
+ * @eventClass
+ * This event is fired whenever the MediaStreamTrack has changed in any way.
+ * @param {MEDIA_STREAM_EVENTS} type - The type of event.
+ * @param {IMediaStreamTrackEventInitDict} eventInitDict - The event init properties.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaStream#events MDN} for details.
+ */
 export default class MediaStreamTrackEvent<TEventType extends MEDIA_STREAM_EVENTS> extends Event<TEventType> {
+    /** @eventProperty */
     track: MediaStreamTrack;
     constructor(type: TEventType, eventInitDict: IMediaStreamTrackEventInitDict) {
         super(type, eventInitDict);

--- a/src/MediaStreamTrackEvent.ts
+++ b/src/MediaStreamTrackEvent.ts
@@ -2,13 +2,15 @@ import { Event } from 'event-target-shim';
 
 import type MediaStreamTrack from './MediaStreamTrack';
 
+type MEDIA_STREAM_EVENTS =  'active'| 'inactive'| 'addtrack'| 'removetrack'
+
 interface IMediaStreamTrackEventInitDict extends Event.EventInit {
   track: MediaStreamTrack;
 }
 
-export default class MediaStreamTrackEvent<TEventType extends string = string> extends Event<TEventType> {
+export default class MediaStreamTrackEvent<TEventType extends MEDIA_STREAM_EVENTS> extends Event<TEventType> {
     track: MediaStreamTrack;
-    constructor(type, eventInitDict: IMediaStreamTrackEventInitDict) {
+    constructor(type: TEventType, eventInitDict: IMediaStreamTrackEventInitDict) {
         super(type, eventInitDict);
         this.track = eventInitDict.track;
     }

--- a/src/MessageEvent.ts
+++ b/src/MessageEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from "event-target-shim"
+import { Event } from 'event-target-shim';
 export type MessageEventData = string | ArrayBuffer | Blob;
 
 interface IMessageEventInitDict extends Event.EventInit {
@@ -8,7 +8,7 @@ interface IMessageEventInitDict extends Event.EventInit {
 export default class MessageEvent<TEventType extends string = string> extends Event<TEventType> {
     data: MessageEventData;
     constructor(type, eventInitDict: IMessageEventInitDict) {
-        super(type, eventInitDict)
+        super(type, eventInitDict);
         this.data = eventInitDict.data;
     }
 }

--- a/src/MessageEvent.ts
+++ b/src/MessageEvent.ts
@@ -1,11 +1,14 @@
-
+import { Event } from "event-target-shim"
 export type MessageEventData = string | ArrayBuffer | Blob;
 
-export default class MessageEvent {
-    type: string;
+interface IMessageEventInitDict extends Event.EventInit {
     data: MessageEventData;
-    constructor(type: string, eventInitDict: { data: MessageEventData }) {
-        this.type = type.toString();
+}
+
+export default class MessageEvent<TEventType extends string = string> extends Event<TEventType> {
+    data: MessageEventData;
+    constructor(type, eventInitDict: IMessageEventInitDict) {
+        super(type, eventInitDict)
         this.data = eventInitDict.data;
     }
 }

--- a/src/MessageEvent.ts
+++ b/src/MessageEvent.ts
@@ -7,7 +7,16 @@ interface IMessageEventInitDict extends Event.EventInit {
     data: MessageEventData;
 }
 
+/**
+ * @eventClass
+ * This event is fired whenever the RTCDataChannel send message.
+ * @param {MESSAGE_EVENTS} type - The type of event.
+ * @param {IMessageEventInitDict} eventInitDict - The event init properties.
+ * @see
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/message_event#event_type MDN} for details.
+ */
 export default class MessageEvent<TEventType extends MESSAGE_EVENTS> extends Event<TEventType> {
+    /** @eventProperty */
     data: MessageEventData;
     constructor(type: TEventType, eventInitDict: IMessageEventInitDict) {
         super(type, eventInitDict);

--- a/src/MessageEvent.ts
+++ b/src/MessageEvent.ts
@@ -1,13 +1,15 @@
 import { Event } from 'event-target-shim';
 export type MessageEventData = string | ArrayBuffer | Blob;
 
+type MESSAGE_EVENTS = 'message' | 'messageerror';
+
 interface IMessageEventInitDict extends Event.EventInit {
     data: MessageEventData;
 }
 
-export default class MessageEvent<TEventType extends string = string> extends Event<TEventType> {
+export default class MessageEvent<TEventType extends MESSAGE_EVENTS> extends Event<TEventType> {
     data: MessageEventData;
-    constructor(type, eventInitDict: IMessageEventInitDict) {
+    constructor(type: TEventType, eventInitDict: IMessageEventInitDict) {
         super(type, eventInitDict);
         this.data = eventInitDict.data;
     }

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -1,6 +1,6 @@
 
 import * as base64 from 'base64-js';
-import {EventTarget} from 'event-target-shim';
+import { EventTarget } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -1,6 +1,6 @@
 
 import * as base64 from 'base64-js';
-import { defineCustomEventTarget } from 'event-target-shim';
+import {EventTarget} from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';
@@ -13,7 +13,16 @@ type RTCDataChannelState = 'connecting' | 'open' | 'closing' | 'closed';
 
 const DATA_CHANNEL_EVENTS = [ 'open', 'message', 'bufferedamountlow', 'closing', 'close', 'error' ];
 
-export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHANNEL_EVENTS) {
+type DataChannelEventMap = {
+    bufferedamountlow: RTCDataChannelEvent<'bufferedamountlow'>;
+    close: RTCDataChannelEvent<'close'>;
+    closing: RTCDataChannelEvent<'closing'>;
+    error: RTCDataChannelEvent<'error'>;
+    message: MessageEvent;
+    open: RTCDataChannelEvent<'open'>;
+};
+
+export default class RTCDataChannel extends EventTarget<DataChannelEventMap> {
     _peerConnectionId: number;
     _reactTag: string;
 
@@ -130,13 +139,10 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
             }
 
             if (this._readyState === 'open') {
-                // @ts-ignore
                 this.dispatchEvent(new RTCDataChannelEvent('open', { channel: this }));
             } else if (this._readyState === 'closing') {
-                // @ts-ignore
                 this.dispatchEvent(new RTCDataChannelEvent('closing', { channel: this }));
             } else if (this._readyState === 'closed') {
-                // @ts-ignore
                 this.dispatchEvent(new RTCDataChannelEvent('close', { channel: this }));
 
                 // This DataChannel is done, clean up event handlers.
@@ -157,7 +163,6 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
                 data = base64.toByteArray(ev.data).buffer;
             }
 
-            // @ts-ignore
             this.dispatchEvent(new MessageEvent('message', { data }));
         });
 
@@ -169,7 +174,6 @@ export default class RTCDataChannel extends defineCustomEventTarget(...DATA_CHAN
             this._bufferedAmount = ev.bufferedAmount;
 
             if (this._bufferedAmount < this.bufferedAmountLowThreshold) {
-                // @ts-ignore
                 this.dispatchEvent(new RTCDataChannelEvent('bufferedamountlow', { channel: this }));
             }
         });

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -11,14 +11,12 @@ const { WebRTCModule } = NativeModules;
 
 type RTCDataChannelState = 'connecting' | 'open' | 'closing' | 'closed';
 
-const DATA_CHANNEL_EVENTS = [ 'open', 'message', 'bufferedamountlow', 'closing', 'close', 'error' ];
-
 type DataChannelEventMap = {
     bufferedamountlow: RTCDataChannelEvent<'bufferedamountlow'>;
     close: RTCDataChannelEvent<'close'>;
     closing: RTCDataChannelEvent<'closing'>;
     error: RTCDataChannelEvent<'error'>;
-    message: MessageEvent;
+    message: MessageEvent<'message'>;
     open: RTCDataChannelEvent<'open'>;
 };
 

--- a/src/RTCDataChannelEvent.ts
+++ b/src/RTCDataChannelEvent.ts
@@ -8,9 +8,18 @@ interface IRTCDataChannelEventInitDict extends Event.EventInit {
     channel: RTCDataChannel;
 }
 
+
+/**
+ * @eventClass
+ * This event is fired whenever the RTCDataChannel has changed in any way.
+ * @param {DATA_CHANNEL_EVENTS} type - The type of event.
+ * @param {IRTCDataChannelEventInitDict} eventInitDict - The event init properties.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel#events MDN} for details.
+ */
 export default class RTCDataChannelEvent<
 TEventType extends DATA_CHANNEL_EVENTS
 > extends Event<TEventType> {
+    /** @eventProperty */
     channel: RTCDataChannel;
     constructor(type: TEventType, eventInitDict: IRTCDataChannelEventInitDict) {
         super(type, eventInitDict);

--- a/src/RTCDataChannelEvent.ts
+++ b/src/RTCDataChannelEvent.ts
@@ -2,18 +2,17 @@ import { Event } from 'event-target-shim';
 
 import type RTCDataChannel from './RTCDataChannel';
 
-type Options = {
-    [K in 'noImplicitAny' | 'strictNullChecks' | 'strictFunctionTypes']?: boolean
-}
+type DATA_CHANNEL_EVENTS =  'open'| 'message'| 'bufferedamountlow'| 'closing'| 'close'| 'error' | 'datachannel';
+
 interface IRTCDataChannelEventInitDict extends Event.EventInit {
     channel: RTCDataChannel;
 }
 
 export default class RTCDataChannelEvent<
-TEventType extends string = string
+TEventType extends DATA_CHANNEL_EVENTS
 > extends Event<TEventType> {
     channel: RTCDataChannel;
-    constructor(type, eventInitDict: IRTCDataChannelEventInitDict) {
+    constructor(type: TEventType, eventInitDict: IRTCDataChannelEventInitDict) {
         super(type, eventInitDict);
         this.channel = eventInitDict.channel;
     }

--- a/src/RTCDataChannelEvent.ts
+++ b/src/RTCDataChannelEvent.ts
@@ -1,8 +1,9 @@
-import { Event } from "event-target-shim"
+import { Event } from 'event-target-shim';
+
 import type RTCDataChannel from './RTCDataChannel';
 
 type Options = {
-    [K in "noImplicitAny" | "strictNullChecks" | "strictFunctionTypes"]?: boolean
+    [K in 'noImplicitAny' | 'strictNullChecks' | 'strictFunctionTypes']?: boolean
 }
 interface IRTCDataChannelEventInitDict extends Event.EventInit {
     channel: RTCDataChannel;

--- a/src/RTCDataChannelEvent.ts
+++ b/src/RTCDataChannelEvent.ts
@@ -1,11 +1,19 @@
-
+import { Event } from "event-target-shim"
 import type RTCDataChannel from './RTCDataChannel';
 
-export default class RTCDataChannelEvent {
-    type: string;
+type Options = {
+    [K in "noImplicitAny" | "strictNullChecks" | "strictFunctionTypes"]?: boolean
+}
+interface IRTCDataChannelEventInitDict extends Event.EventInit {
     channel: RTCDataChannel;
-    constructor(type, eventInitDict: { channel: RTCDataChannel }) {
-        this.type = type.toString();
+}
+
+export default class RTCDataChannelEvent<
+TEventType extends string = string
+> extends Event<TEventType> {
+    channel: RTCDataChannel;
+    constructor(type, eventInitDict: IRTCDataChannelEventInitDict) {
+        super(type, eventInitDict);
         this.channel = eventInitDict.channel;
     }
 }

--- a/src/RTCErrorEvent.ts
+++ b/src/RTCErrorEvent.ts
@@ -1,4 +1,4 @@
-import RTCEvent from './RTCEvent';
+import { Event } from 'event-target-shim';
 
 type RTCPeerConnectionErrorFunc =
     | 'addTransceiver'
@@ -10,10 +10,10 @@ type RTCPeerConnectionErrorFunc =
  * @brief This class Represents internal error happening on the native side as
  * part of asynchronous invocations to synchronous web APIs.
  */
-export default class RTCErrorEvent extends RTCEvent {
+export default class RTCErrorEvent<TEventType extends RTCPeerConnectionErrorFunc> extends Event<TEventType> {
     readonly func: RTCPeerConnectionErrorFunc;
     readonly message: string;
-    constructor(type: string, func: RTCPeerConnectionErrorFunc, message: string) {
+    constructor(type: TEventType, func: RTCPeerConnectionErrorFunc, message: string) {
         super(type);
         this.func = func;
         this.message = message;

--- a/src/RTCEvent.ts
+++ b/src/RTCEvent.ts
@@ -1,7 +1,7 @@
+import { Event } from "event-target-shim"
 
-export default class RTCEvent {
-    type: string;
-    constructor(type) {
-        this.type = type.toString();
+export default class RTCEvent<TEventType extends string = string> extends Event<TEventType> {
+    constructor(type, eventInitDict?: Event.EventInit) {
+        super(type, eventInitDict)
     }
 }

--- a/src/RTCEvent.ts
+++ b/src/RTCEvent.ts
@@ -1,7 +1,10 @@
 import { Event } from 'event-target-shim';
 
-export default class RTCEvent<TEventType extends string = string> extends Event<TEventType> {
-    constructor(type, eventInitDict?: Event.EventInit) {
+type RTC_EVENTS = 'connectionstatechange' | 'iceconnectionstatechange' | 'icegatheringstatechange' |
+ 'negotiationneeded' | 'signalingstatechange' | 'error'
+
+export default class RTCEvent<TEventType extends RTC_EVENTS> extends Event<TEventType> {
+    constructor(type: TEventType, eventInitDict?: Event.EventInit) {
         super(type, eventInitDict);
     }
 }

--- a/src/RTCEvent.ts
+++ b/src/RTCEvent.ts
@@ -1,7 +1,7 @@
-import { Event } from "event-target-shim"
+import { Event } from 'event-target-shim';
 
 export default class RTCEvent<TEventType extends string = string> extends Event<TEventType> {
     constructor(type, eventInitDict?: Event.EventInit) {
-        super(type, eventInitDict)
+        super(type, eventInitDict);
     }
 }

--- a/src/RTCEvent.ts
+++ b/src/RTCEvent.ts
@@ -1,8 +1,19 @@
 import { Event } from 'event-target-shim';
 
+// Import for documentation purposes
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import RTCIceCandidateEvent from './RTCIceCandidateEvent';
+
 type RTC_EVENTS = 'connectionstatechange' | 'iceconnectionstatechange' | 'icegatheringstatechange' |
  'negotiationneeded' | 'signalingstatechange' | 'error'
 
+/**
+ * @eventClass
+ * This event is fired whenever the RTC_EVENTS has changed except on icecandidate related.
+ * @type {RTCIceCandidateEvent} for icecandidate related.
+ * @param {RTC_EVENTS} type - The type of event.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#events MDN} for details.
+ */
 export default class RTCEvent<TEventType extends RTC_EVENTS> extends Event<TEventType> {
     constructor(type: TEventType, eventInitDict?: Event.EventInit) {
         super(type, eventInitDict);

--- a/src/RTCIceCandidateEvent.ts
+++ b/src/RTCIceCandidateEvent.ts
@@ -1,10 +1,11 @@
-import { Event } from "event-target-shim"
+import { Event } from 'event-target-shim';
+
 import type RTCIceCandidate from './RTCIceCandidate';
 
 interface IRTCDataChannelEventInitDict extends Event.EventInit {
     candidate: RTCIceCandidate | null
 }
-  
+
 export default class RTCIceCandidateEvent<TEventType extends string = string> extends Event<TEventType> {
     candidate: RTCIceCandidate | null;
     constructor(type, eventInitDict: IRTCDataChannelEventInitDict) {

--- a/src/RTCIceCandidateEvent.ts
+++ b/src/RTCIceCandidateEvent.ts
@@ -2,13 +2,15 @@ import { Event } from 'event-target-shim';
 
 import type RTCIceCandidate from './RTCIceCandidate';
 
+type RTC_ICECANDIDATE_EVENTS = 'icecandidate' | 'icecandidateerror'
+
 interface IRTCDataChannelEventInitDict extends Event.EventInit {
     candidate: RTCIceCandidate | null
 }
 
-export default class RTCIceCandidateEvent<TEventType extends string = string> extends Event<TEventType> {
+export default class RTCIceCandidateEvent<TEventType extends RTC_ICECANDIDATE_EVENTS> extends Event<TEventType> {
     candidate: RTCIceCandidate | null;
-    constructor(type, eventInitDict: IRTCDataChannelEventInitDict) {
+    constructor(type: TEventType, eventInitDict: IRTCDataChannelEventInitDict) {
         super(type, eventInitDict);
         this.candidate = eventInitDict?.candidate ?? null;
     }

--- a/src/RTCIceCandidateEvent.ts
+++ b/src/RTCIceCandidateEvent.ts
@@ -1,11 +1,14 @@
-
+import { Event } from "event-target-shim"
 import type RTCIceCandidate from './RTCIceCandidate';
 
-export default class RTCIceCandidateEvent {
-    type: string;
+interface IRTCDataChannelEventInitDict extends Event.EventInit {
+    candidate: RTCIceCandidate | null
+}
+  
+export default class RTCIceCandidateEvent<TEventType extends string = string> extends Event<TEventType> {
     candidate: RTCIceCandidate | null;
-    constructor(type, eventInitDict) {
-        this.type = type.toString();
+    constructor(type, eventInitDict: IRTCDataChannelEventInitDict) {
+        super(type, eventInitDict);
         this.candidate = eventInitDict?.candidate ?? null;
     }
 }

--- a/src/RTCIceCandidateEvent.ts
+++ b/src/RTCIceCandidateEvent.ts
@@ -8,7 +8,16 @@ interface IRTCDataChannelEventInitDict extends Event.EventInit {
     candidate: RTCIceCandidate | null
 }
 
+/**
+ * @eventClass
+ * This event is fired whenever the icecandidate related RTC_EVENTS changed.
+ * @type {RTCIceCandidateEvent} for icecandidate related.
+ * @param {RTC_ICECANDIDATE_EVENTS} type - The type of event.
+ * @param {IRTCDataChannelEventInitDict} eventInitDict - The event init properties.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#events MDN} for details.
+ */
 export default class RTCIceCandidateEvent<TEventType extends RTC_ICECANDIDATE_EVENTS> extends Event<TEventType> {
+    /** @eventProperty */
     candidate: RTCIceCandidate | null;
     constructor(type: TEventType, eventInitDict: IRTCDataChannelEventInitDict) {
         super(type, eventInitDict);

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -1,5 +1,5 @@
 
-import { defineCustomEventTarget } from 'event-target-shim';
+import { EventTarget } from 'event-target-shim';
 import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';
@@ -60,9 +60,22 @@ const PEER_CONNECTION_EVENTS = [
     'error'
 ];
 
+type RTCPeerConnectionEventMap = {
+    connectionstatechange: RTCEvent<"connectionstatechange">
+    icecandidate: RTCIceCandidateEvent<"icecandidate">
+    // icecandidateerror: RTCIceCandidateEvent<"icecandidateerror">
+    iceconnectionstatechange: RTCEvent<"iceconnectionstatechange">
+    icegatheringstatechange: RTCEvent<"icegatheringstatechange">
+    negotiationneeded: RTCEvent<"negotiationneeded">
+    signalingstatechange: RTCEvent<"signalingstatechange">
+    datachannel: RTCDataChannelEvent<"datachannel">
+    track: RTCTrackEvent<"track">
+    error: RTCEvent<"error">
+  }
+
 let nextPeerConnectionId = 0;
 
-export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_CONNECTION_EVENTS) {
+export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEventMap> {
     signalingState: RTCSignalingState = 'stable';
     iceGatheringState: RTCIceGatheringState = 'new';
     connectionState: RTCPeerConnectionState = 'new';
@@ -279,11 +292,10 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                 receiver: transceiver.receiver
             };
 
-            // @ts-ignore
+
             this.dispatchEvent(new RTCTrackEvent('track', eventData));
 
             streams.forEach(stream => {
-                // @ts-ignore
                 stream.dispatchEvent(new MediaStreamTrackEvent('addtrack', { track }));
             });
 
@@ -546,7 +558,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                 return;
             }
 
-            // @ts-ignore
             this.dispatchEvent(new RTCEvent('negotiationneeded'));
         });
 
@@ -557,7 +568,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
             this.iceConnectionState = ev.iceConnectionState;
 
-            // @ts-ignore
             this.dispatchEvent(new RTCEvent('iceconnectionstatechange'));
         });
 
@@ -568,7 +578,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
             this.connectionState = ev.connectionState;
 
-            // @ts-ignore
             this.dispatchEvent(new RTCEvent('connectionstatechange'));
 
             if (ev.connectionState === 'closed') {
@@ -621,7 +630,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                 this._pendingRemoteDescription = null;
             }
 
-            // @ts-ignore
             this.dispatchEvent(new RTCEvent('signalingstatechange'));
         });
 
@@ -663,7 +671,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
                         stream._tracks.splice(trackIdx, 1);
 
-                        // @ts-ignore
                         stream.dispatchEvent(new MediaStreamTrackEvent('removetrack', { track }));
 
                         // Dispatch a mute event for the track.
@@ -696,7 +703,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
             const candidate = new RTCIceCandidate(ev.candidate);
 
-            // @ts-ignore
             this.dispatchEvent(new RTCIceCandidateEvent('icecandidate', { candidate }));
         });
 
@@ -724,11 +730,9 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
                     this._pendingLocalDescription = null;
                 }
 
-                // @ts-ignore
                 this.dispatchEvent(new RTCIceCandidateEvent('icecandidate', { candidate: null }));
             }
 
-            // @ts-ignore
             this.dispatchEvent(new RTCEvent('icegatheringstatechange'));
         });
 
@@ -739,7 +743,6 @@ export default class RTCPeerConnection extends defineCustomEventTarget(...PEER_C
 
             const channel = new RTCDataChannel(ev.dataChannel);
 
-            // @ts-ignore
             this.dispatchEvent(new RTCDataChannelEvent('datachannel', { channel }));
         });
 

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -47,23 +47,10 @@ type RTCDataChannelInit = {
     id?: number
 };
 
-const PEER_CONNECTION_EVENTS = [
-    'connectionstatechange',
-    'icecandidate',
-    'icecandidateerror',
-    'iceconnectionstatechange',
-    'icegatheringstatechange',
-    'negotiationneeded',
-    'signalingstatechange',
-    'datachannel',
-    'track',
-    'error'
-];
-
 type RTCPeerConnectionEventMap = {
     connectionstatechange: RTCEvent<'connectionstatechange'>
     icecandidate: RTCIceCandidateEvent<'icecandidate'>
-    // icecandidateerror: RTCIceCandidateEvent<"icecandidateerror">
+    icecandidateerror: RTCIceCandidateEvent<'icecandidateerror'>
     iceconnectionstatechange: RTCEvent<'iceconnectionstatechange'>
     icegatheringstatechange: RTCEvent<'icegatheringstatechange'>
     negotiationneeded: RTCEvent<'negotiationneeded'>

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -61,16 +61,16 @@ const PEER_CONNECTION_EVENTS = [
 ];
 
 type RTCPeerConnectionEventMap = {
-    connectionstatechange: RTCEvent<"connectionstatechange">
-    icecandidate: RTCIceCandidateEvent<"icecandidate">
+    connectionstatechange: RTCEvent<'connectionstatechange'>
+    icecandidate: RTCIceCandidateEvent<'icecandidate'>
     // icecandidateerror: RTCIceCandidateEvent<"icecandidateerror">
-    iceconnectionstatechange: RTCEvent<"iceconnectionstatechange">
-    icegatheringstatechange: RTCEvent<"icegatheringstatechange">
-    negotiationneeded: RTCEvent<"negotiationneeded">
-    signalingstatechange: RTCEvent<"signalingstatechange">
-    datachannel: RTCDataChannelEvent<"datachannel">
-    track: RTCTrackEvent<"track">
-    error: RTCEvent<"error">
+    iceconnectionstatechange: RTCEvent<'iceconnectionstatechange'>
+    icegatheringstatechange: RTCEvent<'icegatheringstatechange'>
+    negotiationneeded: RTCEvent<'negotiationneeded'>
+    signalingstatechange: RTCEvent<'signalingstatechange'>
+    datachannel: RTCDataChannelEvent<'datachannel'>
+    track: RTCTrackEvent<'track'>
+    error: RTCEvent<'error'>
   }
 
 let nextPeerConnectionId = 0;

--- a/src/RTCTrackEvent.ts
+++ b/src/RTCTrackEvent.ts
@@ -1,4 +1,5 @@
-import { Event } from "event-target-shim"
+import { Event } from 'event-target-shim';
+
 import MediaStream from './MediaStream';
 import type MediaStreamTrack from './MediaStreamTrack';
 import RTCRtpReceiver from './RTCRtpReceiver';

--- a/src/RTCTrackEvent.ts
+++ b/src/RTCTrackEvent.ts
@@ -5,18 +5,20 @@ import type MediaStreamTrack from './MediaStreamTrack';
 import RTCRtpReceiver from './RTCRtpReceiver';
 import RTCRtpTransceiver from './RTCRtpTransceiver';
 
+type TRACK_EVENTS = 'track'
+
 interface IRTCTrackEventInitDict extends Event.EventInit {
     streams: MediaStream[]
     transceiver: RTCRtpTransceiver
 }
 
-export default class RTCTrackEvent<TEventType extends string = string> extends Event<TEventType> {
+export default class RTCTrackEvent<TEventType extends TRACK_EVENTS> extends Event<TEventType> {
     readonly streams: MediaStream[] = [];
     readonly transceiver: RTCRtpTransceiver;
     readonly receiver: RTCRtpReceiver | null;
     readonly track: MediaStreamTrack | null;
 
-    constructor(type, eventInitDict: IRTCTrackEventInitDict) {
+    constructor(type: TEventType, eventInitDict: IRTCTrackEventInitDict) {
         super(type, eventInitDict);
         this.streams = eventInitDict.streams;
         this.transceiver = eventInitDict.transceiver;

--- a/src/RTCTrackEvent.ts
+++ b/src/RTCTrackEvent.ts
@@ -1,18 +1,22 @@
-
+import { Event } from "event-target-shim"
 import MediaStream from './MediaStream';
 import type MediaStreamTrack from './MediaStreamTrack';
 import RTCRtpReceiver from './RTCRtpReceiver';
 import RTCRtpTransceiver from './RTCRtpTransceiver';
 
-export default class RTCTrackEvent {
-    type: string;
+interface IRTCTrackEventInitDict extends Event.EventInit {
+    streams: MediaStream[]
+    transceiver: RTCRtpTransceiver
+}
+
+export default class RTCTrackEvent<TEventType extends string = string> extends Event<TEventType> {
     readonly streams: MediaStream[] = [];
     readonly transceiver: RTCRtpTransceiver;
     readonly receiver: RTCRtpReceiver | null;
     readonly track: MediaStreamTrack | null;
 
-    constructor(type: string, eventInitDict: { streams: MediaStream[], transceiver: RTCRtpTransceiver }) {
-        this.type = type.toString();
+    constructor(type, eventInitDict: IRTCTrackEventInitDict) {
+        super(type, eventInitDict);
         this.streams = eventInitDict.streams;
         this.transceiver = eventInitDict.transceiver;
         this.receiver = eventInitDict.transceiver.receiver;

--- a/src/RTCTrackEvent.ts
+++ b/src/RTCTrackEvent.ts
@@ -12,10 +12,24 @@ interface IRTCTrackEventInitDict extends Event.EventInit {
     transceiver: RTCRtpTransceiver
 }
 
+/**
+ * @eventClass
+ * This event is fired whenever the Track is changed in PeerConnection.
+ * @param {TRACK_EVENTS} type - The type of event.
+ * @param {IRTCTrackEventInitDict} eventInitDict - The event init properties.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/track_event MDN} for details.
+ */
 export default class RTCTrackEvent<TEventType extends TRACK_EVENTS> extends Event<TEventType> {
+    /** @eventProperty */
     readonly streams: MediaStream[] = [];
+
+    /** @eventProperty */
     readonly transceiver: RTCRtpTransceiver;
+
+    /** @eventProperty */
     readonly receiver: RTCRtpReceiver | null;
+
+    /** @eventProperty */
     readonly track: MediaStreamTrack | null;
 
     constructor(type: TEventType, eventInitDict: IRTCTrackEventInitDict) {


### PR DESCRIPTION
#### Fix #1432 
Add type to most of event that from event-target-shimmer

- MediaStreamTrackEvent
- MessageEvent
- RTCIceCandidateEvent
- RTCTrackEvent