### PR TITLE
[plan-b] Add releaseWebrtcModule() global function

### DIFF
--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -15,7 +15,8 @@ import {
 	MediaStream,
 	MediaStreamTrack,
 	mediaDevices,
-	registerGlobals
+	registerGlobals,
+	releaseWebrtcModule
 } from 'react-native-webrtc';
 ```
 
@@ -335,3 +336,9 @@ Don't forget, the user facing camera is usually mirrored.
 | objectFit | string | 'contain' | Can be `'contain'` or `'cover'` nothing more or less. | 
 | streamURL | string | 'streamURL' | Required to have an actual video stream rendering. |
 | zOrder | number | 0 | Similar to zIndex. |
+
+## Releasing WebRTC Handles
+
+After a call, internal WebRTC dependencies remain in a live state to be used in subsequent calls. If you wish to release these handles,
+perhaps before your app goes into background or won't be used for a while, you can call the `releaseWebrtcModule()` global function. After calling this function, necessary dependencies will be lazily reacquired before the next call.
+

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -98,7 +98,7 @@ class GetUserMediaImpl {
         Log.d(TAG, "getUserMedia(audio): " + audioConstraintsMap);
 
         String id = UUID.randomUUID().toString();
-        PeerConnectionFactory pcFactory = webRTCModule.mFactory;
+        PeerConnectionFactory pcFactory = webRTCModule.getPeerConnectionFactory();
         MediaConstraints peerConstraints = webRTCModule.constraintsForOptions(audioConstraintsMap);
 
         //PeerConnectionFactory.createAudioSource will throw an error when mandatory constraints contain nulls.
@@ -305,7 +305,7 @@ class GetUserMediaImpl {
 
     private void createStream(MediaStreamTrack[] tracks, BiConsumer<String, ArrayList<WritableMap>> successCallback) {
         String streamId = UUID.randomUUID().toString();
-        MediaStream mediaStream = webRTCModule.mFactory.createLocalMediaStream(streamId);
+        MediaStream mediaStream = webRTCModule.getPeerConnectionFactory().createLocalMediaStream(streamId);
 
         ArrayList<WritableMap> tracksInfo = new ArrayList<>();
 
@@ -366,7 +366,7 @@ class GetUserMediaImpl {
             return null;
         }
 
-        PeerConnectionFactory pcFactory = webRTCModule.mFactory;
+        PeerConnectionFactory pcFactory = webRTCModule.getPeerConnectionFactory();
         EglBase.Context eglContext = EglUtils.getRootEglBaseContext();
         SurfaceTextureHelper surfaceTextureHelper =
             SurfaceTextureHelper.create("CaptureThread", eglContext);

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -30,8 +30,8 @@
  */
 - (RTCAudioTrack *)createAudioTrack:(NSDictionary *)constraints {
   NSString *trackId = [[NSUUID UUID] UUIDString];
-  RTCAudioTrack *audioTrack
-    = [self.peerConnectionFactory audioTrackWithTrackId:trackId];
+  RTCAudioTrack *audioTrack =
+      [[self getPeerConnectionFactory] audioTrackWithTrackId:trackId];
   return audioTrack;
 }
 
@@ -39,10 +39,12 @@
  * Initializes a new {@link RTCVideoTrack} which satisfies the given constraints.
  */
 - (RTCVideoTrack *)createVideoTrack:(NSDictionary *)constraints {
-  RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+  RTCVideoSource *videoSource = [[self getPeerConnectionFactory] videoSource];
 
   NSString *trackUUID = [[NSUUID UUID] UUIDString];
-  RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+  RTCVideoTrack *videoTrack =
+      [[self getPeerConnectionFactory] videoTrackWithSource:videoSource
+                                                    trackId:trackUUID];
 
 #if !TARGET_IPHONE_SIMULATOR
   RTCCameraVideoCapturer *videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
@@ -61,10 +63,13 @@
     return nil;
 #endif
 
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSourceForScreenCast:YES];
+    RTCVideoSource *videoSource =
+        [[self getPeerConnectionFactory] videoSourceForScreenCast:YES];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    RTCVideoTrack *videoTrack =
+        [[self getPeerConnectionFactory] videoTrackWithSource:videoSource
+                                                      trackId:trackUUID];
 
     ScreenCapturer *screenCapturer = [[ScreenCapturer alloc] initWithDelegate:videoSource];
     ScreenCaptureController *screenCaptureController = [[ScreenCaptureController alloc] initWithCapturer:screenCapturer];
@@ -84,8 +89,8 @@ RCT_EXPORT_METHOD(getDisplayMedia:(RCTPromiseResolveBlock)resolve
     }
 
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream
-      = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    RTCMediaStream *mediaStream =
+        [[self getPeerConnectionFactory] mediaStreamWithStreamId:mediaStreamId];
     [mediaStream addVideoTrack:videoTrack];
 
     NSString *trackId = videoTrack.trackId;
@@ -132,8 +137,8 @@ RCT_EXPORT_METHOD(getUserMedia:(NSDictionary *)constraints
   }
 
   NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-  RTCMediaStream *mediaStream
-    = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+  RTCMediaStream *mediaStream =
+      [[self getPeerConnectionFactory] mediaStreamWithStreamId:mediaStreamId];
   NSMutableArray *tracks = [NSMutableArray array];
   NSMutableArray *tmp = [NSMutableArray array];
   if (audioTrack)
@@ -231,8 +236,9 @@ RCT_EXPORT_METHOD(enumerateDevices:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(mediaStreamCreate:(nonnull NSString *)streamID)
 {
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:streamID];
-    self.localStreams[streamID] = mediaStream;
+  RTCMediaStream *mediaStream =
+      [[self getPeerConnectionFactory] mediaStreamWithStreamId:streamID];
+  self.localStreams[streamID] = mediaStream;
 }
 
 RCT_EXPORT_METHOD(mediaStreamAddTrack:(nonnull NSString *)streamID : (nonnull NSString *)trackID)

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -93,18 +93,18 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit:(RTCConfiguration*)con
         RTCMediaConstraints* constraints =
             [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil
                                                   optionalConstraints:optionalConstraints];
-          RTCPeerConnection *peerConnection
-            = [self.peerConnectionFactory peerConnectionWithConfiguration:configuration
-                                                              constraints:constraints
-                                                                 delegate:self];
-          peerConnection.dataChannels = [NSMutableDictionary new];
-          peerConnection.reactTag = objectID;
-          peerConnection.remoteStreams = [NSMutableDictionary new];
-          peerConnection.remoteTracks = [NSMutableDictionary new];
-          peerConnection.videoTrackAdapters = [NSMutableDictionary new];
-          peerConnection.webRTCModule = self;
+        RTCPeerConnection *peerConnection = [[self getPeerConnectionFactory]
+            peerConnectionWithConfiguration:configuration
+                                constraints:constraints
+                                   delegate:self];
+        peerConnection.dataChannels = [NSMutableDictionary new];
+        peerConnection.reactTag = objectID;
+        peerConnection.remoteStreams = [NSMutableDictionary new];
+        peerConnection.remoteTracks = [NSMutableDictionary new];
+        peerConnection.videoTrackAdapters = [NSMutableDictionary new];
+        peerConnection.webRTCModule = self;
 
-          self.peerConnections[objectID] = peerConnection;
+        self.peerConnections[objectID] = peerConnection;
     });
 
     return nil;

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -37,8 +37,6 @@ static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMut
 
 @property(nonatomic, strong) dispatch_queue_t workerQueue;
 
-@property (nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
-
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, RTCPeerConnection *> *peerConnections;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
@@ -47,5 +45,7 @@ static NSString *const kEventMediaStreamTrackMuteChanged = @"mediaStreamTrackMut
                         decoderFactory:(id<RTCVideoDecoderFactory>)decoderFactory;
 
 - (RTCMediaStream*)streamForReactTag:(NSString*)reactTag;
+
+- (RTCPeerConnectionFactory*)getPeerConnectionFactory;
 
 @end

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { NativeModules } from 'react-native';
 import ScreenCapturePickerView from './ScreenCapturePickerView';
 import RTCPeerConnection from './RTCPeerConnection';
 import RTCIceCandidate from './RTCIceCandidate';
@@ -7,6 +8,8 @@ import MediaStream from './MediaStream';
 import MediaStreamTrack from './MediaStreamTrack';
 import mediaDevices from './MediaDevices';
 import permissions from './Permissions';
+
+const { WebRTCModule } = NativeModules;
 
 export {
     ScreenCapturePickerView,
@@ -18,7 +21,8 @@ export {
     MediaStreamTrack,
     mediaDevices,
     permissions,
-    registerGlobals
+    registerGlobals,
+    releaseWebrtcModule
 };
 
 function registerGlobals(): void {
@@ -40,4 +44,8 @@ function registerGlobals(): void {
     global.RTCSessionDescription = RTCSessionDescription;
     global.MediaStream = MediaStream;
     global.MediaStreamTrack = MediaStreamTrack;
+}
+
+function releaseWebrtcModule(): void {
+    WebRTCModule.releaseWebrtc();
 }


### PR DESCRIPTION
Adds `releaseWebrtcModule()` as a global function.

When making subsequent calls, it was observed that the internal WebRTC audio processing module, and associated dependencies were reused across calls. This does not match the behaviour of Chromium, where the WebRTC dependencies are properly torn down after all calls.

Additionally, dependencies remained resident in memory even when the app was idle and backgrounded, which is not ideal from a memory footprint point of view.

PS: This PR is opened against `plan-b` branch precisely because that branch is based on M106 which is where these changes were originally developed and tested.