### PR TITLE
Add releaseWebrtcModule() global function

### DIFF
--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -15,7 +15,8 @@ import {
 	MediaStream,
 	MediaStreamTrack,
 	mediaDevices,
-	registerGlobals
+	registerGlobals,
+	releaseWebrtcModule
 } from 'react-native-webrtc';
 ```
 
@@ -346,3 +347,9 @@ It takes in a number between 0 to 10, defaults to 1.
 const audioTrack = remoteMediaStream.getAudioTracks()[0];
 audioTrack._setVolume(0.5);
 ```
+
+## Releasing WebRTC Handles
+
+After a call, internal WebRTC dependencies remain in a live state to be used in subsequent calls. If you wish to release these handles,
+perhaps before your app goes into background or won't be used for a while, you can call the `releaseWebrtcModule()` global function. After calling this function, necessary dependencies will be lazily reacquired before the next call.
+

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -101,7 +101,7 @@ class GetUserMediaImpl {
         Log.d(TAG, "getUserMedia(audio): " + audioConstraintsMap);
 
         String id = UUID.randomUUID().toString();
-        PeerConnectionFactory pcFactory = webRTCModule.mFactory;
+        PeerConnectionFactory pcFactory = webRTCModule.getPeerConnectionFactory();
         MediaConstraints peerConstraints = webRTCModule.constraintsForOptions(audioConstraintsMap);
 
         // PeerConnectionFactory.createAudioSource will throw an error when mandatory constraints contain nulls.
@@ -300,7 +300,7 @@ class GetUserMediaImpl {
 
     void createStream(MediaStreamTrack[] tracks, BiConsumer<String, ArrayList<WritableMap>> successCallback) {
         String streamId = UUID.randomUUID().toString();
-        MediaStream mediaStream = webRTCModule.mFactory.createLocalMediaStream(streamId);
+        MediaStream mediaStream = webRTCModule.getPeerConnectionFactory().createLocalMediaStream(streamId);
 
         ArrayList<WritableMap> tracksInfo = new ArrayList<>();
 
@@ -360,7 +360,7 @@ class GetUserMediaImpl {
             return null;
         }
 
-        PeerConnectionFactory pcFactory = webRTCModule.mFactory;
+        PeerConnectionFactory pcFactory = webRTCModule.getPeerConnectionFactory();
         EglBase.Context eglContext = EglUtils.getRootEglBaseContext();
         SurfaceTextureHelper surfaceTextureHelper = SurfaceTextureHelper.create("CaptureThread", eglContext);
 

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -88,6 +88,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                 encoderFactory = new SoftwareVideoEncoderFactory();
                 decoderFactory = new SoftwareVideoDecoderFactory();
             }
+        }
 
         Log.d(TAG, "Using video encoder factory: " + encoderFactory.getClass().getCanonicalName());
         Log.d(TAG, "Using video decoder factory: " + decoderFactory.getClass().getCanonicalName());

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -40,8 +40,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     static final String TAG = WebRTCModule.class.getCanonicalName();
 
     private final ReactApplicationContext reactContext;
-
-    PeerConnectionFactory mFactory;
+    private PeerConnectionFactory mFactory;
     VideoEncoderFactory mVideoEncoderFactory;
     VideoDecoderFactory mVideoDecoderFactory;
 
@@ -1338,14 +1337,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             .setEnableVolumeLogger(false)
             .createAudioDeviceModule();
 
-        this.mFactory
-            = PeerConnectionFactory.builder()
-                .setAudioDeviceModule(adm)
-                .setVideoEncoderFactory(encoderFactory)
-                .setVideoDecoderFactory(decoderFactory)
-                .createPeerConnectionFactory();
-
-        mFactory = PeerConnectionFactory.builder()
+        this.mFactory = PeerConnectionFactory.builder()
                             .setAudioDeviceModule(adm)
                             .setVideoEncoderFactory(this.encoderFactory)
                             .setVideoDecoderFactory(this.decoderFactory)

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1340,8 +1340,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
 
         this.mFactory = PeerConnectionFactory.builder()
                             .setAudioDeviceModule(adm)
-                            .setVideoEncoderFactory(this.encoderFactory)
-                            .setVideoDecoderFactory(this.decoderFactory)
+                            .setVideoEncoderFactory(this.mVideoEncoderFactory)
+                            .setVideoDecoderFactory(this.mVideoDecoderFactory)
                             .createPeerConnectionFactory();
 
         return this.mFactory;

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -26,7 +26,7 @@
  */
 - (RTCAudioTrack *)createAudioTrack:(NSDictionary *)constraints {
     NSString *trackId = [[NSUUID UUID] UUIDString];
-    RTCAudioTrack *audioTrack = [self.peerConnectionFactory audioTrackWithTrackId:trackId];
+    RTCAudioTrack *audioTrack = [[self getPeerConnectionFactory] audioTrackWithTrackId:trackId];
     return audioTrack;
 }
 
@@ -35,10 +35,10 @@
  */
 - (RTCVideoTrack *)createVideoTrackWithCaptureController:
     (CaptureController * (^)(RTCVideoSource *))captureControllerCreator {
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+    RTCVideoSource *videoSource = [[self getPeerConnectionFactory] videoSource];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    RTCVideoTrack *videoTrack = [[self getPeerConnectionFactory] videoTrackWithSource:videoSource trackId:trackUUID];
 
     CaptureController *captureController = captureControllerCreator(videoSource);
     videoTrack.captureController = captureController;
@@ -54,7 +54,7 @@
  */
 - (NSArray *)createMediaStream:(NSArray<RTCMediaStreamTrack *> *)tracks {
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    RTCMediaStream *mediaStream = [[self getPeerConnectionFactory] mediaStreamWithStreamId:mediaStreamId];
     NSMutableArray<NSDictionary *> *trackInfos = [NSMutableArray array];
 
     for (RTCMediaStreamTrack *track in tracks) {
@@ -97,10 +97,10 @@
  * Initializes a new {@link RTCVideoTrack} which satisfies the given constraints.
  */
 - (RTCVideoTrack *)createVideoTrack:(NSDictionary *)constraints {
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+    RTCVideoSource *videoSource = [[self getPeerConnectionFactory] videoSource];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    RTCVideoTrack *videoTrack = [[self getPeerConnectionFactory] videoTrackWithSource:videoSource trackId:trackUUID];
 
 #if !TARGET_IPHONE_SIMULATOR
     RTCCameraVideoCapturer *videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
@@ -118,10 +118,10 @@
     return nil;
 #endif
 
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSourceForScreenCast:YES];
+    RTCVideoSource *videoSource = [[self getPeerConnectionFactory] videoSourceForScreenCast:YES];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    RTCVideoTrack *videoTrack = [[self getPeerConnectionFactory] videoTrackWithSource:videoSource trackId:trackUUID];
 
     ScreenCapturer *screenCapturer = [[ScreenCapturer alloc] initWithDelegate:videoSource];
     ScreenCaptureController *screenCaptureController =
@@ -144,7 +144,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     }
 
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    RTCMediaStream *mediaStream = [[self getPeerConnectionFactory] mediaStreamWithStreamId:mediaStreamId];
     [mediaStream addVideoTrack:videoTrack];
 
     NSString *trackId = videoTrack.trackId;
@@ -191,7 +191,7 @@ RCT_EXPORT_METHOD(getUserMedia
     }
 
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    RTCMediaStream *mediaStream = [[self getPeerConnectionFactory] mediaStreamWithStreamId:mediaStreamId];
     NSMutableArray *tracks = [NSMutableArray array];
     NSMutableArray *tmp = [NSMutableArray array];
     if (audioTrack)
@@ -280,7 +280,7 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
 }
 
 RCT_EXPORT_METHOD(mediaStreamCreate : (nonnull NSString *)streamID) {
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:streamID];
+    RTCMediaStream *mediaStream = [[self getPeerConnectionFactory] mediaStreamWithStreamId:streamID];
     self.localStreams[streamID] = mediaStream;
 }
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -80,9 +80,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
         NSDictionary *optionalConstraints = @{@"DtlsSrtpKeyAgreement" : @"true"};
         RTCMediaConstraints *constraints =
             [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil optionalConstraints:optionalConstraints];
-        RTCPeerConnection *peerConnection = [self.peerConnectionFactory peerConnectionWithConfiguration:configuration
-                                                                                            constraints:constraints
-                                                                                               delegate:self];
+        RTCPeerConnection *peerConnection =
+            [[self getPeerConnectionFactory] peerConnectionWithConfiguration:configuration
+                                                                 constraints:constraints
+                                                                    delegate:self];
         peerConnection.dataChannels = [NSMutableDictionary new];
         peerConnection.reactTag = objectID;
         peerConnection.remoteStreams = [NSMutableDictionary new];

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -26,7 +26,6 @@ static NSString *const kEventPeerConnectionOnTrack = @"peerConnectionOnTrack";
 
 @property(nonatomic, strong) dispatch_queue_t workerQueue;
 
-@property(nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
 @property(nonatomic, strong) id<RTCVideoDecoderFactory> decoderFactory;
 @property(nonatomic, strong) id<RTCVideoEncoderFactory> encoderFactory;
 
@@ -35,5 +34,7 @@ static NSString *const kEventPeerConnectionOnTrack = @"peerConnectionOnTrack";
 @property(nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
 
 - (RTCMediaStream *)streamForReactTag:(NSString *)reactTag;
+
+- (RTCPeerConnectionFactory *)getPeerConnectionFactory;
 
 @end

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,8 @@ export {
     MediaStreamTrack,
     mediaDevices,
     permissions,
-    registerGlobals
+    registerGlobals,
+    releaseWebrtcModule
 };
 
 declare const global: any;
@@ -75,4 +76,8 @@ function registerGlobals(): void {
     global.RTCRtpReceiver = RTCRtpReceiver;
     global.RTCRtpSender = RTCRtpSender;
     global.RTCErrorEvent = RTCErrorEvent;
+}
+
+function releaseWebrtcModule(): void {
+    WebRTCModule.releaseWebrtc();
 }


### PR DESCRIPTION
Forward port of #1434

Adds `releaseWebrtcModule()` as a global function.

When making subsequent calls, it was observed that the internal WebRTC audio processing module, and associated dependencies were reused across calls. This does not match the behaviour of Chromium, where the WebRTC dependencies are properly torn down after all calls.

Additionally, dependencies remained resident in memory even when the app was idle and backgrounded, which is not ideal from a memory footprint point of view.