### PR TITLE
Android, fix default transceiver direction

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/SerializeUtils.java
+++ b/android/src/main/java/com/oney/WebRTCModule/SerializeUtils.java
@@ -280,7 +280,7 @@ public class SerializeUtils {
             return null;
         }
 
-        RtpTransceiver.RtpTransceiverDirection direction = RtpTransceiver.RtpTransceiverDirection.INACTIVE;
+        RtpTransceiver.RtpTransceiverDirection direction = RtpTransceiver.RtpTransceiverDirection.SEND_RECV;
         List<String> streamIds = new ArrayList<>();
         List<RtpParameters.Encoding> sendEncodings = new ArrayList<>();
 


### PR DESCRIPTION
Android is using `INACTIVE` rather than `SEND_RECV` as the default transceiver direction.
Simple change to resolve the issue and put things inline with iOS and [spec](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverinit).

Closes #1441 