### PR TITLE
Improve typing of RTCIceCandidate and MediaStream

### DIFF
--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -41,7 +41,11 @@ export default class MediaStream extends EventTarget<MediaStreamEventMap> {
      *   done internally, when the stream is first created in native and the JS wrapper is
      *   built afterwards.
      */
-    constructor(arg) {
+    constructor(arg?: 
+        MediaStream | 
+        MediaStreamTrack[] | 
+        { streamId: string, streamReactTag: string, tracks: MediaStreamTrack[] }
+    ) {
         super();
 
         // Assign a UUID to start with. It will get overridden for remote streams.

--- a/src/MediaStream.ts
+++ b/src/MediaStream.ts
@@ -41,9 +41,9 @@ export default class MediaStream extends EventTarget<MediaStreamEventMap> {
      *   done internally, when the stream is first created in native and the JS wrapper is
      *   built afterwards.
      */
-    constructor(arg?: 
-        MediaStream | 
-        MediaStreamTrack[] | 
+    constructor(arg?:
+        MediaStream |
+        MediaStreamTrack[] |
         { streamId: string, streamReactTag: string, tracks: MediaStreamTrack[] }
     ) {
         super();

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -1,14 +1,21 @@
+interface RTCIceCandidateInfo {
+    candidate?: string;
+    sdpMLineIndex: number | null;
+    sdpMid: string | null;
+}
+
 export default class RTCIceCandidate {
     candidate: string;
     sdpMLineIndex: number;
     sdpMid: string;
 
-    constructor({ candidate = '', sdpMLineIndex = null, sdpMid = null }) {
+    constructor(info: RTCIceCandidateInfo) {
+        const { candidate, sdpMLineIndex, sdpMid } = info;
         if (sdpMLineIndex === null || sdpMid === null) {
             throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null');
         }
 
-        this.candidate = candidate;
+        this.candidate = candidate ?? '';
         this.sdpMLineIndex = sdpMLineIndex;
         this.sdpMid = sdpMid;
     }

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -10,13 +10,13 @@ export default class RTCIceCandidate {
     sdpMid: string;
 
     constructor(info: RTCIceCandidateInfo) {
-        const { candidate, sdpMLineIndex, sdpMid } = info;
-        // == null checks for both null and undefined, but not for other falsy values
-        if (sdpMLineIndex == null || sdpMid == null) {
+        const { candidate = '', sdpMLineIndex = null, sdpMid = null } = info;
+
+        if (sdpMLineIndex === null || sdpMid === null) {
             throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null');
         }
 
-        this.candidate = candidate ?? '';
+        this.candidate = candidate;
         this.sdpMLineIndex = sdpMLineIndex;
         this.sdpMid = sdpMid;
     }

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -9,9 +9,7 @@ export default class RTCIceCandidate {
     sdpMLineIndex: number;
     sdpMid: string;
 
-    constructor(info: RTCIceCandidateInfo) {
-        const { candidate = '', sdpMLineIndex = null, sdpMid = null } = info;
-
+    constructor({ candidate = '', sdpMLineIndex = null, sdpMid = null }: RTCIceCandidateInfo) {
         if (sdpMLineIndex === null || sdpMid === null) {
             throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null');
         }

--- a/src/RTCIceCandidate.ts
+++ b/src/RTCIceCandidate.ts
@@ -1,7 +1,7 @@
 interface RTCIceCandidateInfo {
     candidate?: string;
-    sdpMLineIndex: number | null;
-    sdpMid: string | null;
+    sdpMLineIndex?: number | null;
+    sdpMid?: string | null;
 }
 
 export default class RTCIceCandidate {
@@ -11,7 +11,8 @@ export default class RTCIceCandidate {
 
     constructor(info: RTCIceCandidateInfo) {
         const { candidate, sdpMLineIndex, sdpMid } = info;
-        if (sdpMLineIndex === null || sdpMid === null) {
+        // == null checks for both null and undefined, but not for other falsy values
+        if (sdpMLineIndex == null || sdpMid == null) {
             throw new TypeError('`sdpMLineIndex` and `sdpMid` must not null');
         }
 


### PR DESCRIPTION
The type of the constructor parameter is currently 
```
{  candidate?: string, sdpMLineIndex?: null, sdpMid?: null }
```
which causes TypeScript errors despite valid parameters like

```
new RTCIceCandidate({candidate: 'candidateString', sdpMLineIndex: 0, sdpMid: 'sdpMidString'});
```

This fix allows constructing the class without TypeScript issues.

As far as I can tell, shouldn't cause issues to any existing implementations.

EDIT:
Added typing for MediaStream constructor, too.