### PR TITLE
pc: handle PC initialization failures

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -367,16 +367,20 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    public void peerConnectionInit(ReadableMap configuration, int id) {
+    public boolean peerConnectionInit(ReadableMap configuration, int id) {
         PeerConnection.RTCConfiguration rtcConfiguration = parseRTCConfiguration(configuration);
 
         try {
-            ThreadUtils
+            return (boolean) ThreadUtils
                     .submitToExecutor(() -> {
                         PeerConnectionObserver observer = new PeerConnectionObserver(this, id);
                         PeerConnection peerConnection = mFactory.createPeerConnection(rtcConfiguration, observer);
+                        if (peerConnection == null) {
+                            return false;
+                        }
                         observer.setPeerConnection(peerConnection);
                         mPeerConnectionObservers.put(id, observer);
+                        return true;
                     })
                     .get();
         } catch (ExecutionException | InterruptedException e) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -79,9 +79,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
     __block BOOL ret = YES;
 
     dispatch_sync(self.workerQueue, ^{
-        NSDictionary *optionalConstraints = @{@"DtlsSrtpKeyAgreement" : @"true"};
-        RTCMediaConstraints *constraints =
-            [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil optionalConstraints:optionalConstraints];
+        RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil
+                                                                                 optionalConstraints:nil];
         RTCPeerConnection *peerConnection = [self.peerConnectionFactory peerConnectionWithConfiguration:configuration
                                                                                             constraints:constraints
                                                                                                delegate:self];

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -76,6 +76,8 @@ int _transceiverNextId = 0;
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
                                        : (RTCConfiguration *)configuration objectID
                                        : (nonnull NSNumber *)objectID) {
+    __block BOOL ret = YES;
+
     dispatch_sync(self.workerQueue, ^{
         NSDictionary *optionalConstraints = @{@"DtlsSrtpKeyAgreement" : @"true"};
         RTCMediaConstraints *constraints =
@@ -83,6 +85,11 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
         RTCPeerConnection *peerConnection = [self.peerConnectionFactory peerConnectionWithConfiguration:configuration
                                                                                             constraints:constraints
                                                                                                delegate:self];
+        if (peerConnection == nil) {
+            ret = NO;
+            return;
+        }
+
         peerConnection.dataChannels = [NSMutableDictionary new];
         peerConnection.reactTag = objectID;
         peerConnection.remoteStreams = [NSMutableDictionary new];
@@ -93,7 +100,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
         self.peerConnections[objectID] = peerConnection;
     });
 
-    return nil;
+    return @(ret);
 }
 
 RCT_EXPORT_METHOD(peerConnectionSetConfiguration

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -82,7 +82,10 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
         super();
 
         this._pcId = nextPeerConnectionId++;
-        WebRTCModule.peerConnectionInit(configuration, this._pcId);
+
+        if (!WebRTCModule.peerConnectionInit(configuration, this._pcId)) {
+            throw new Error('Failed to initialize PeerConnection, check the native logs!');
+        }
 
         this._transceivers = [];
         this._remoteStreams = new Map();


### PR DESCRIPTION
It should usually only trigger for bugs in the library, but things will break in very weird ways otherwise.

Ref: https://github.com/react-native-webrtc/react-native-webrtc/issues/1453