### PR TITLE
fix(android): release JavaAudioDeviceModule via onCatalystInstanceDestroy method

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -42,6 +42,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     PeerConnectionFactory mFactory;
     VideoEncoderFactory mVideoEncoderFactory;
     VideoDecoderFactory mVideoDecoderFactory;
+    AudioDeviceModule mAudioDeviceModule;
 
     // Need to expose the peer connection codec factories here to get capabilities
     private final SparseArray<PeerConnectionObserver> mPeerConnectionObservers;
@@ -103,6 +104,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         // Saving the encoder and decoder factories to get codec info later when needed.
         mVideoEncoderFactory = encoderFactory;
         mVideoDecoderFactory = decoderFactory;
+        mAudioDeviceModule = adm;
 
         getUserMediaImpl = new GetUserMediaImpl(this, reactContext);
     }
@@ -111,6 +113,14 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return "WebRTCModule";
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        if (mAudioDeviceModule != null) {
+            mAudioDeviceModule.release();
+        }
+        super.onCatalystInstanceDestroy();
     }
 
     private PeerConnection getPeerConnection(int id) {


### PR DESCRIPTION
When WebRTCModule is initialized twice, app crashes.
To reproduce:
1. before WebRTCModule is initialized(such as `Application.onCreate()`), inject new `audioDeviceModule` created by `JavaAudioDeviceModule.builder` in `WebRTCModuleOptions.getInstance()`.
2. Apply Codepush update, which triggers React Context to be recreated.
3. WebRTCModule is initialized again, then it crashes when executing `createPeerConnectionFactory` (https://github.com/react-native-webrtc/react-native-webrtc/blob/master/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java#L97)

I think its because `nativeAudioDeviceModule` cannot be created twice.

If I release existing audio device module before executing `createPeerConnectionFactory`, the app does not crash.