### PR TITLE
Replaced deprecated `AVCaptureDeviceTypeBuiltInMicrophone` with `AVCaptureDeviceTypeMicrophone`

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -286,7 +286,7 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
         }];
     }
     AVCaptureDeviceDiscoverySession *audioDevicesSession =
-        [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInMicrophone ]
+        [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeMicrophone ]
                                                                mediaType:AVMediaTypeAudio
                                                                 position:AVCaptureDevicePositionUnspecified];
     for (AVCaptureDevice *device in audioDevicesSession.devices) {


### PR DESCRIPTION
`AVCaptureDeviceTypeBuiltInMicrophone` is deprecated  https://developer.apple.com/documentation/avfoundation/avcapturedevicetypebuiltinmicrophone

`AVCaptureDeviceTypeMicrophone` is replacement as per the docs.