### PR TITLE
dc: send open event after datachannel event

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -707,6 +707,10 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
             const channel = new RTCDataChannel(ev.dataChannel);
 
             this.dispatchEvent(new RTCDataChannelEvent('datachannel', { channel }));
+
+            // Send 'open' event. Native doesn't update the state since it's already
+            // set at this point.
+            channel.dispatchEvent(new RTCDataChannelEvent('open', { channel }));
         });
 
         addListener(this, 'mediaStreamTrackMuteChanged', (ev: any) => {


### PR DESCRIPTION
Fixes: https://github.com/react-native-webrtc/react-native-webrtc/issues/1498