### PR TITLE
docs: Add foreground service type perms to android docs

### DIFF
--- a/Documentation/AndroidInstallation.md
+++ b/Documentation/AndroidInstallation.md
@@ -64,6 +64,14 @@ In `android/app/main/AndroidManifest.xml` add the following inside the `<applica
 	android:foregroundServiceType="mediaProjection|camera|microphone" />
 ```
 
+Additionally, add the respective foreground service type permissions before the `<application>` section.
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+```
+
 The following will create an ongoing persistent notification which also comes with a foreground service.  
 You will be prompted for permissions automatically each time you want to initialise screen capturing.  
 A notification channel is also required and created.  


### PR DESCRIPTION
New permission is required for screen share in Android 14:

https://developer.android.com/about/versions/14/changes/fgs-types-required