### PR TITLE
android, ios: remove track when removed from peerconnection

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -483,10 +483,7 @@ class PeerConnectionObserver implements PeerConnection.Observer {
             params.putInt("pcId", this.id);
             params.putString("receiverId", receiver.id());
 
-            MediaStreamTrack track = remoteTracks.remove(receiver.id());
-            if (track != null) {
-                track.dispose();
-            }
+            remoteTracks.remove(receiver.id());
 
             webRTCModule.sendEvent("peerConnectionOnRemoveTrack", params);
         });

--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -483,6 +483,11 @@ class PeerConnectionObserver implements PeerConnection.Observer {
             params.putInt("pcId", this.id);
             params.putString("receiverId", receiver.id());
 
+            MediaStreamTrack track = remoteTracks.remove(receiver.id());
+            if (track != null) {
+                track.dispose();
+            }
+
             webRTCModule.sendEvent("peerConnectionOnRemoveTrack", params);
         });
     };

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -922,6 +922,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
         params[@"pcId"] = peerConnection.reactTag;
         params[@"receiverId"] = rtpReceiver.receiverId;
 
+        [peerConnection.remoteTracks removeObjectForKey:rtpReceiver.receiverId];
+
         [self sendEventWithName:kEventPeerConnectionOnRemoveTrack body:params];
     });
 }


### PR DESCRIPTION
Not sure if this was an intentional omission, but I noticed that a track is kept around after it has been removed from the peer connection. This was causing issues when the track with the same id was added back to the peer connection, as any calls on the track at the JS layer would be pointed at the stale track. Are there any issues with removing the track here?