### PR TITLE
android,ios: don't reject promise for getStats when peer connection doesn't exist

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -255,9 +255,9 @@ class PeerConnectionObserver implements PeerConnection.Observer {
 
     public void senderGetStats(String senderId, Promise promise) {
         RtpSender targetSender = null;
-        for (RtpSender r : peerConnection.getSenders()) {
-            if (r.id().equals(senderId)) {
-                targetSender = r;
+        for (RtpSender s : peerConnection.getSenders()) {
+            if (s.id().equals(senderId)) {
+                targetSender = s;
                 break;
             }
         }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1245,7 +1245,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             PeerConnectionObserver pco = mPeerConnectionObservers.get(pcId);
             if (pco == null || pco.getPeerConnection() == null) {
                 Log.d(TAG, "receiverGetStats() peerConnection is null");
-                promise.reject(new Exception("PeerConnection ID not found"));
+                promise.resolve(StringUtils.statsToJSON(new RTCStatsReport(0, new HashMap<>())));
             } else {
                 pco.receiverGetStats(receiverId, promise);
             }
@@ -1258,7 +1258,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             PeerConnectionObserver pco = mPeerConnectionObservers.get(pcId);
             if (pco == null || pco.getPeerConnection() == null) {
                 Log.d(TAG, "senderGetStats() peerConnection is null");
-                promise.reject(new Exception("PeerConnection ID not found"));
+                promise.resolve(StringUtils.statsToJSON(new RTCStatsReport(0, new HashMap<>())));
             } else {
                 pco.senderGetStats(senderId, promise);
             }
@@ -1311,7 +1311,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             PeerConnectionObserver pco = mPeerConnectionObservers.get(peerConnectionId);
             if (pco == null || pco.getPeerConnection() == null) {
                 Log.d(TAG, "peerConnectionGetStats() peerConnection is null");
-                promise.reject(new Exception("PeerConnection ID not found"));
+                promise.resolve(StringUtils.statsToJSON(new RTCStatsReport(0, new HashMap<>())));
             } else {
                 pco.getStats(promise);
             }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -354,7 +354,8 @@ RCT_EXPORT_METHOD(peerConnectionGetStats
                   : (RCTPromiseRejectBlock)reject) {
     RTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
-        reject(@"invalid_id", @"PeerConnection ID not found", nil);
+        RCTLogWarn(@"PeerConnection %@ not found in peerConnectionGetStats()", objectID);
+        resolve(@"[]");
         return;
     }
 
@@ -370,7 +371,8 @@ RCT_EXPORT_METHOD(receiverGetStats
                   : (RCTPromiseRejectBlock)reject) {
     RTCPeerConnection *peerConnection = self.peerConnections[pcId];
     if (!peerConnection) {
-        reject(@"invalid_id", @"PeerConnection ID not found", nil);
+        RCTLogWarn(@"PeerConnection %@ not found in receiverGetStats()", pcId);
+        resolve(@"[]");
         return;
     }
 
@@ -383,7 +385,8 @@ RCT_EXPORT_METHOD(receiverGetStats
     }
 
     if (!receiver) {
-        reject(@"invalid_id", @"Receiver ID not found", nil);
+        RCTLogWarn(@"RTCRtpReceiver %@ not found in receiverGetStats()", receiverId);
+        resolve(@"[]");
         return;
     }
 
@@ -400,7 +403,8 @@ RCT_EXPORT_METHOD(senderGetStats
                   : (RCTPromiseRejectBlock)reject) {
     RTCPeerConnection *peerConnection = self.peerConnections[pcId];
     if (!peerConnection) {
-        reject(@"invalid_id", @"PeerConnection ID not found", nil);
+        RCTLogWarn(@"PeerConnection %@ not found in senderGetStats()", pcId);
+        resolve(@"[]");
         return;
     }
 
@@ -413,7 +417,8 @@ RCT_EXPORT_METHOD(senderGetStats
     }
 
     if (!sender) {
-        reject(@"invalid_id", @"Sender ID not found", nil);
+        RCTLogWarn(@"RTCRtpSender %@ not found in senderGetStats()", senderId);
+        resolve(@"[]");
         return;
     }
 


### PR DESCRIPTION
Browsers don't seem to fail for `getStats()` on closed peer connections/senders/receivers (and the spec doesn't seem to allow for rejecting it). For RTCRtpSender/Receivers, they return an empty stats report, while there's a lone entry for peer connections:

```
{
    "id": "P",
    "timestamp": 1712746990577.823,
    "type": "peer-connection",
    "dataChannelsClosed": 0,
    "dataChannelsOpened": 2
}
```

To closer align with the spec, this PR just has them all return empty maps if the native equivalent can't be found.