### PR TITLE
compat: Add RTCVideoView to the new Interop Layer - RN 0.72+

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,11 +1,20 @@
 'use strict';
 
+module.exports = {
+    project: {
+        android: {
+            unstable_reactLegacyComponentNames: [ 'RTCVideoView' ]
+        },
+        ios: {
+            unstable_reactLegacyComponentNames: [ 'RTCVideoView' ]
+        }
+    }
+};
+
 const macSwitch = '--use-react-native-macos';
 
 if (process.argv.includes(macSwitch)) {
     process.argv = process.argv.filter(arg => arg !== macSwitch);
     process.argv.push('--config=metro.config.macos.js');
-    module.exports = {
-        reactNativePath: 'node_modules/react-native-macos'
-    };
+    module.exports.reactNativePath = 'node_modules/react-native-macos';
 }


### PR DESCRIPTION
There is plenty to do when it comes to converting everything over to the latest RN standards but until then this will allow people to use the New Architecture in their project.

More info over [here](https://github.com/reactwg/react-native-new-architecture/discussions/135).
Will test soon 😄 