### PR TITLE
ios: fix not being able to deactivate encodings

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+Transceivers.m
+++ b/ios/RCTWebRTC/WebRTCModule+Transceivers.m
@@ -269,7 +269,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(transceiverSetCodecPreferences
         NSDictionary *encodingUpdate = encodingsArray[i];
         RTCRtpEncodingParameters *encoding = encodings[i];
 
-        encoding.isActive = encodingUpdate[@"active"];
+        encoding.isActive = [encodingUpdate[@"active"] boolValue];
         encoding.rid = encodingUpdate[@"rid"];
         encoding.maxBitrateBps = encodingUpdate[@"maxBitrate"];
         encoding.maxFramerate = encodingUpdate[@"maxFramerate"];

--- a/src/RTCRtpEncodingParameters.ts
+++ b/src/RTCRtpEncodingParameters.ts
@@ -66,7 +66,7 @@ export default class RTCRtpEncodingParameters {
 
     toJSON(): RTCRtpEncodingParametersInit {
         const obj = {
-            active: this.active,
+            active: Boolean(this.active),
         };
 
         if (this._rid !== null) {


### PR DESCRIPTION
This must have been one of the nastiest bugs to catch.

The JS layer passes the encoding parameters as JSON, which includes the "active" element set to the boolean value `true`. RN converts that to an NSDictionary, but since NSDictionary doesn't support booleans (BOOL is a C type, not an Obj-C type) the boolean values get converted to NSNumber. Assigning any NSNumber to a BOOL will always result in a true value, because it's actually an object! In order to get the actual boolean value one has to use `boolValue`: `[theNumber boolValue]`, which returns BOOL.

So yeah, if your simulcast layer suspension code is mysteriously not working on iOS... this is why :-P