### PR TITLE
Use custom webrtc.xcframework to suppress microphone permissions

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -45,6 +45,7 @@
         id<RTCVideoEncoderFactory> encoderFactory = options.videoEncoderFactory;
         NSDictionary *fieldTrials = options.fieldTrials;
         RTCLoggingSeverity loggingSeverity = options.loggingSeverity;
+        bool audioRecvOnly = options.audioReceiveOnlyMode;
 
         // Initialize field trials.
         if (fieldTrials == nil) {
@@ -56,6 +57,14 @@
 
         // Initialize logging.
         RTCSetMinDebugLogLevel(loggingSeverity);
+
+        // Configure Webrtc Audio Session to be recvOnly mode
+        if (audioRecvOnly) {
+          RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *webRTCConfig =
+              [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+          webRTCConfig.recvOnlyMode = true;
+          [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) setWebRTCConfiguration:webRTCConfig];
+        }
 
         if (encoderFactory == nil) {
             encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];

--- a/ios/RCTWebRTC/WebRTCModuleOptions.h
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) id<RTCAudioDevice> audioDevice;
 @property(nonatomic, strong, nullable) NSDictionary *fieldTrials;
 @property(nonatomic, assign) RTCLoggingSeverity loggingSeverity;
+@property(atomic, assign) Boolean audioReceiveOnlyMode;
 
 #pragma mark - This class is a singleton
 

--- a/ios/RCTWebRTC/WebRTCModuleOptions.m
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.m
@@ -22,6 +22,7 @@
         self.videoEncoderFactory = nil;
         self.videoDecoderFactory = nil;
         self.loggingSeverity = RTCLoggingSeverityNone;
+        self.audioReceiveOnlyMode = true;
     }
 
     return self;

--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -19,5 +19,7 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'JitsiWebRTC', '~> 118.0.0'
+
+  # Note: Need to be supplied by a private pod specs repo
+  s.dependency          'RNMillicastWebRTC', '~> 118.0.0'
 end


### PR DESCRIPTION
Consume a custom libwebrtc for iOS devices that fixes the unwanted microphone permissions