### PR TITLE
fix: Handle invalidate for react-native 0.74+

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -117,6 +117,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @Override
+    public void invalidate() {
+        onCatalystInstanceDestroy();
+    }
+
+    @Override
     public void onCatalystInstanceDestroy() {
         if (mAudioDeviceModule != null) {
             mAudioDeviceModule.release();


### PR DESCRIPTION
React-Native no longer calls onCatalystInstanceDestroy in 0.74+ (used to be called when the app reloaded). On 0.74+, this has been replaced by `invalidate()`.

This was causing crashes for consumers who use a custom AudioDeviceModule (as well as perhaps leaking the old ADM for those who use the default).