### PR TITLE
android: release audio device module after creating factory

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -102,6 +102,9 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
                            .setVideoDecoderFactory(decoderFactory)
                            .createPeerConnectionFactory();
 
+        // PeerConnectionFactory now owns the adm native pointer, and we don't need it anymore.
+        adm.release();
+
         // Saving the encoder and decoder factories to get codec info later when needed.
         mVideoEncoderFactory = encoderFactory;
         mVideoDecoderFactory = decoderFactory;
@@ -114,14 +117,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return "WebRTCModule";
-    }
-
-    @Override
-    public void onCatalystInstanceDestroy() {
-        if (mAudioDeviceModule != null) {
-            mAudioDeviceModule.release();
-        }
-        super.onCatalystInstanceDestroy();
     }
 
     private PeerConnection getPeerConnection(int id) {


### PR DESCRIPTION
JavaAudioDeviceModule can be released after creating the PeerConnectionFactory, as per the sdk example:

https://webrtc.googlesource.com/src/+/4e86aa0870e5e34031a320e9ef95e86c897ffa4e/examples/androidapp/src/org/appspot/apprtc/PeerConnectionClient.java#456

Note that this only releases the native pointer and doesn't make the module itself inoperable.

This PR also fixes the behavior for RN 0.74+, as `onCatalystInstanceDestroy` (which was responsible for calling `release`) is no longer called there.