### PR TITLE
android: declare dependency on androidx.core 1.7.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,4 +31,5 @@ android {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'org.jitsi:webrtc:124.+'
+    implementation "androidx.core:core:1.7.0"
 }


### PR DESCRIPTION
Some older versions of react native (occurs on 0.68 at least) pull in an old version of `androidx.core`, causing the build to fail to build on those versions.

The particular one I encountered was:

```
error: cannot find symbol
                .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE);
                                                                ^
  symbol:   variable FOREGROUND_SERVICE_IMMEDIATE
  location: class NotificationCompat
```

This variable is introduced in androidx.core@1.7.0, so I've added the dependency to the build.gradle to make that requirement explicit.