### PR TITLE
android: report actual size in camera MediaStreamTrack settings

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -3,9 +3,13 @@ package com.oney.WebRTCModule;
 import org.webrtc.VideoCapturer;
 
 public abstract class AbstractVideoCaptureController {
-    private final int width;
-    private final int height;
-    private final int fps;
+    protected final int targetWidth;
+    protected final int targetHeight;
+    protected final int targetFps;
+
+    protected int actualWidth;
+    protected int actualHeight;
+    protected int actualFps;
 
     /**
      * {@link VideoCapturer} which this controller manages.
@@ -15,9 +19,12 @@ public abstract class AbstractVideoCaptureController {
     protected CapturerEventsListener capturerEventsListener;
 
     public AbstractVideoCaptureController(int width, int height, int fps) {
-        this.width = width;
-        this.height = height;
-        this.fps = fps;
+        this.targetWidth = width;
+        this.targetHeight = height;
+        this.targetFps = fps;
+        this.actualWidth = width;
+        this.actualHeight = height;
+        this.actualFps = fps;
     }
 
     public void initializeVideoCapturer() {
@@ -32,15 +39,15 @@ public abstract class AbstractVideoCaptureController {
     }
 
     public int getHeight() {
-        return height;
+        return actualHeight;
     }
 
     public int getWidth() {
-        return width;
+        return actualWidth;
     }
 
     public int getFrameRate() {
-        return fps;
+        return actualFps;
     }
 
     public VideoCapturer getVideoCapturer() {
@@ -49,7 +56,7 @@ public abstract class AbstractVideoCaptureController {
 
     public void startCapture() {
         try {
-            videoCapturer.startCapture(width, height, fps);
+            videoCapturer.startCapture(targetWidth, targetHeight, targetFps);
         } catch (RuntimeException e) {
             // XXX This can only fail if we initialize the capturer incorrectly,
             // which we don't. Thus, ignore any failures here since we trust

--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -1,11 +1,20 @@
 package com.oney.WebRTCModule;
 
+import android.content.Context;
+import android.hardware.camera2.CameraManager;
 import android.util.Log;
+import android.util.Pair;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 
+import org.webrtc.Camera1Capturer;
+import org.webrtc.Camera1Helper;
+import org.webrtc.Camera2Capturer;
+import org.webrtc.Camera2Helper;
 import org.webrtc.CameraEnumerator;
 import org.webrtc.CameraVideoCapturer;
+import org.webrtc.Size;
 import org.webrtc.VideoCapturer;
 
 import java.util.ArrayList;
@@ -19,6 +28,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
 
     private boolean isFrontFacing;
 
+    private final Context context;
     private final CameraEnumerator cameraEnumerator;
     private final ReadableMap constraints;
 
@@ -30,9 +40,10 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
      */
     private final CameraEventsHandler cameraEventsHandler = new CameraEventsHandler();
 
-    public CameraCaptureController(CameraEnumerator cameraEnumerator, ReadableMap constraints) {
+    public CameraCaptureController(Context context, CameraEnumerator cameraEnumerator, ReadableMap constraints) {
         super(constraints.getInt("width"), constraints.getInt("height"), constraints.getInt("frameRate"));
 
+        this.context = context;
         this.cameraEnumerator = cameraEnumerator;
         this.constraints = constraints;
     }
@@ -75,7 +86,30 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         String deviceId = ReactBridgeUtil.getMapStrValue(this.constraints, "deviceId");
         String facingMode = ReactBridgeUtil.getMapStrValue(this.constraints, "facingMode");
 
-        return createVideoCapturer(deviceId, facingMode);
+        Pair<String, VideoCapturer> result = createVideoCapturer(deviceId, facingMode);
+        if(result == null) {
+            return null;
+        }
+
+        String cameraName = result.first;
+        VideoCapturer videoCapturer = result.second;
+
+        // Find actual capture format.
+        Size actualSize = null;
+        if (videoCapturer instanceof Camera1Capturer) {
+            int cameraId = Camera1Helper.getCameraId(cameraName);
+            actualSize = Camera1Helper.findClosestCaptureFormat(cameraId, targetWidth, targetHeight);
+        } else if (videoCapturer instanceof Camera2Capturer) {
+            CameraManager cameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+            actualSize = Camera2Helper.findClosestCaptureFormat(cameraManager, cameraName, targetWidth, targetHeight);
+        }
+
+        if (actualSize != null) {
+            actualWidth = actualSize.width;
+            actualHeight = actualSize.height;
+        }
+
+        return videoCapturer;
     }
 
     /**
@@ -117,10 +151,11 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
      * @param facingMode the facing of the requested video source such as
      * {@code user} and {@code environment}. If {@code null}, "user" is
      * presumed.
-     * @return a {@code VideoCapturer} satisfying the {@code facingMode} or
-     * {@code deviceId} constraint
+     * @return a pair containing the deviceId and {@code VideoCapturer} satisfying the {@code facingMode} or
+     * {@code deviceId} constraint, or null.
      */
-    private VideoCapturer createVideoCapturer(String deviceId, String facingMode) {
+    @Nullable
+    private Pair<String, VideoCapturer> createVideoCapturer(String deviceId, String facingMode) {
         String[] deviceNames = cameraEnumerator.getDeviceNames();
         List<String> failedDevices = new ArrayList<>();
 
@@ -139,7 +174,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
             if (videoCapturer != null) {
                 Log.d(TAG, message + " succeeded");
                 this.isFrontFacing = cameraEnumerator.isFrontFacing(cameraName);
-                return videoCapturer;
+                return new Pair(cameraName, videoCapturer);
             } else {
                 // fallback to facingMode
                 Log.d(TAG, message + " failed");
@@ -161,7 +196,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
             if (videoCapturer != null) {
                 Log.d(TAG, message + " succeeded");
                 this.isFrontFacing = cameraEnumerator.isFrontFacing(name);
-                return videoCapturer;
+                return new Pair(name, videoCapturer);
             } else {
                 Log.d(TAG, message + " failed");
                 failedDevices.add(name);
@@ -176,7 +211,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
                 if (videoCapturer != null) {
                     Log.d(TAG, message + " succeeded");
                     this.isFrontFacing = cameraEnumerator.isFrontFacing(name);
-                    return videoCapturer;
+                    return new Pair(name, videoCapturer);
                 } else {
                     Log.d(TAG, message + " failed");
                     failedDevices.add(name);

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -192,7 +192,7 @@ class GetUserMediaImpl {
             Log.d(TAG, "getUserMedia(video): " + videoConstraintsMap);
 
             CameraCaptureController cameraCaptureController =
-                    new CameraCaptureController(getCameraEnumerator(), videoConstraintsMap);
+                    new CameraCaptureController(reactContext.getCurrentActivity(), getCameraEnumerator(), videoConstraintsMap);
 
             videoTrack = createVideoTrack(cameraCaptureController);
         }

--- a/android/src/main/java/org/webrtc/Camera1Helper.java
+++ b/android/src/main/java/org/webrtc/Camera1Helper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023-2024 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.webrtc;
+
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper to access package-protected methods used in [Camera2Session]
+ * <p>
+ * Note: cameraId as used in the Camera1XXX classes refers to the index within the list of cameras.
+ *
+ * @suppress
+ */
+
+public class Camera1Helper {
+
+    public static int getCameraId(String deviceName) {
+        return Camera1Enumerator.getCameraIndex(deviceName);
+    }
+
+    @Nullable
+    public static List<CameraEnumerationAndroid.CaptureFormat> getSupportedFormats(int cameraId) {
+        return Camera1Enumerator.getSupportedFormats(cameraId);
+    }
+
+    public static Size findClosestCaptureFormat(int cameraId, int width, int height) {
+        List<CameraEnumerationAndroid.CaptureFormat> formats = getSupportedFormats(cameraId);
+
+        List<Size> sizes = new ArrayList<>();
+        if (formats != null) {
+            for (CameraEnumerationAndroid.CaptureFormat format : formats) {
+                sizes.add(new Size(format.width, format.height));
+            }
+        }
+
+        return CameraEnumerationAndroid.getClosestSupportedSize(sizes, width, height);
+    }
+}

--- a/android/src/main/java/org/webrtc/Camera2Helper.java
+++ b/android/src/main/java/org/webrtc/Camera2Helper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-2024 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.webrtc;
+
+import android.hardware.camera2.CameraManager;
+
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper to access package-protected methods used in [Camera2Session]
+ * <p>
+ * Note: cameraId as used in the Camera2XXX classes refers to the id returned
+ * by [CameraManager.getCameraIdList].
+ */
+public class Camera2Helper {
+
+    @Nullable
+    public static List<CameraEnumerationAndroid.CaptureFormat> getSupportedFormats(CameraManager cameraManager, @Nullable String cameraId) {
+        return Camera2Enumerator.getSupportedFormats(cameraManager, cameraId);
+    }
+
+    public static Size findClosestCaptureFormat(CameraManager cameraManager, @Nullable String cameraId, int width, int height) {
+        List<CameraEnumerationAndroid.CaptureFormat> formats = getSupportedFormats(cameraManager, cameraId);
+
+        List<Size> sizes = new ArrayList<>();
+        if (formats != null) {
+            for (CameraEnumerationAndroid.CaptureFormat format : formats) {
+                sizes.add(new Size(format.width, format.height));
+            }
+        }
+
+        return CameraEnumerationAndroid.getClosestSupportedSize(sizes, width, height);
+    }
+}


### PR DESCRIPTION
MediaStreamTrack.getSettings() should report the actual values rather than the target constraints; this PR grabs the size that the camera capturer will eventually resolve to.