### PR TITLE
sender: fix serializing RTCRtpSendParameters

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -342,7 +342,7 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
 
         const newSdp = await WebRTCModule.peerConnectionAddICECandidate(
             this._pcId,
-            candidate.toJSON ? candidate.toJSON() : candidate
+            RTCUtil.deepClone(candidate)
         );
 
         this.remoteDescription = new RTCSessionDescription(newSdp);

--- a/src/RTCRtpParameters.ts
+++ b/src/RTCRtpParameters.ts
@@ -1,6 +1,7 @@
 import RTCRtcpParameters, { RTCRtcpParametersInit } from './RTCRtcpParameters';
 import RTCRtpCodecParameters, { RTCRtpCodecParametersInit } from './RTCRtpCodecParameters';
 import RTCRtpHeaderExtension, { RTCRtpHeaderExtensionInit } from './RTCRtpHeaderExtension';
+import { deepClone } from './RTCUtil';
 
 
 export interface RTCRtpParametersInit {
@@ -10,7 +11,7 @@ export interface RTCRtpParametersInit {
 }
 
 export default class RTCRtpParameters {
-    readonly codecs: RTCRtpCodecParameters[] = [];
+    codecs: (RTCRtpCodecParameters | RTCRtpCodecParametersInit)[] = [];
     readonly headerExtensions: RTCRtpHeaderExtension[] = [];
     readonly rtcp: RTCRtcpParameters;
 
@@ -26,11 +27,11 @@ export default class RTCRtpParameters {
         this.rtcp = new RTCRtcpParameters(init.rtcp);
     }
 
-    toJSON(): RTCRtpParametersInit {
+    toJSON() {
         return {
-            codecs: this.codecs.map(c => c.toJSON()),
-            headerExtensions: this.headerExtensions.map(he => he.toJSON()),
-            rtcp: this.rtcp.toJSON()
+            codecs: this.codecs.map(c => deepClone(c)),
+            headerExtensions: this.headerExtensions.map(he => deepClone(he)),
+            rtcp: deepClone(this.rtcp)
         };
     }
 }

--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -48,7 +48,7 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
         }
     }
 
-    toJSON(): RTCRtpSendParametersInit {
+    toJSON() {
         const obj = super.toJSON();
 
         obj['transactionId'] = this.transactionId;
@@ -58,6 +58,6 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
             obj['degradationPreference'] = DegradationPreference.toNative(this.degradationPreference);
         }
 
-        return obj as RTCRtpSendParametersInit;
+        return obj;
     }
 }

--- a/src/RTCRtpSendParameters.ts
+++ b/src/RTCRtpSendParameters.ts
@@ -1,5 +1,6 @@
 import RTCRtpEncodingParameters, { RTCRtpEncodingParametersInit } from './RTCRtpEncodingParameters';
 import RTCRtpParameters, { RTCRtpParametersInit } from './RTCRtpParameters';
+import { deepClone } from './RTCUtil';
 
 type DegradationPreferenceType = 'maintain-framerate'
     | 'maintain-resolution'
@@ -31,7 +32,7 @@ export interface RTCRtpSendParametersInit extends RTCRtpParametersInit {
 
 export default class RTCRtpSendParameters extends RTCRtpParameters {
     readonly transactionId: string;
-    readonly encodings: RTCRtpEncodingParameters[];
+    encodings: (RTCRtpEncodingParameters | RTCRtpEncodingParametersInit)[];
     degradationPreference: DegradationPreferenceType | null;
 
     constructor(init: RTCRtpSendParametersInit) {
@@ -51,8 +52,7 @@ export default class RTCRtpSendParameters extends RTCRtpParameters {
         const obj = super.toJSON();
 
         obj['transactionId'] = this.transactionId;
-
-        obj['encodings'] = this.encodings.map(e => e.toJSON());
+        obj['encodings'] = this.encodings.map(e => deepClone(e));
 
         if (this.degradationPreference !== null) {
             obj['degradationPreference'] = DegradationPreference.toNative(this.degradationPreference);


### PR DESCRIPTION
It's possible for user code to replace encodings entirely. Thus, the resulting array will not have RTCRtpEncodingParameters object instances, but plain objects.

Handle it by deep-cloning the objects with JSON.parse(JSON.stringify(x)) since that will take care of appropriately serializing them, no matter the type.