### PR TITLE
ios,android: add device/groupId to MediaStreamTrack.getSettings and implement applyConstraints

### DIFF
--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -307,8 +307,18 @@ try {
 	// Taken from above, we don't want to flip if we don't have another camera.
 	if ( cameraCount < 2 ) { return; };
 
-	const videoTrack = await localMediaStream.getVideoTracks()[ 0 ];
-	videoTrack._switchCamera();
+	const videoTrack = localMediaStream.getVideoTracks()[0];
+
+	let constraints;
+	if (isFrontCam) {
+		constraints = { facingMode: 'environment' };
+	} else {
+		constraints = { facingMode: 'user' };
+	}
+
+	videoTrack.applyConstraints(constraints);
+	// _switchCamera is deprecated as of 124.0.5
+	// videoTrack._switchCamera();
 
 	isFrontCam = !isFrontCam;
 } catch( err ) {

--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -308,15 +308,10 @@ try {
 	if ( cameraCount < 2 ) { return; };
 
 	const videoTrack = localMediaStream.getVideoTracks()[0];
-
-	let constraints;
-	if (isFrontCam) {
-		constraints = { facingMode: 'environment' };
-	} else {
-		constraints = { facingMode: 'user' };
-	}
+	const constraints = { facingMode: isFrontCam ? 'user' : 'environment' };
 
 	videoTrack.applyConstraints(constraints);
+
 	// _switchCamera is deprecated as of 124.0.5
 	// videoTrack._switchCamera();
 

--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -1,5 +1,7 @@
 package com.oney.WebRTCModule;
 
+import androidx.annotation.Nullable;
+
 import org.webrtc.VideoCapturer;
 
 public abstract class AbstractVideoCaptureController {
@@ -30,6 +32,9 @@ public abstract class AbstractVideoCaptureController {
     public void initializeVideoCapturer() {
         videoCapturer = createVideoCapturer();
     }
+
+    @Nullable
+    public abstract String getDeviceId();
 
     public void dispose() {
         if (videoCapturer != null) {

--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -2,12 +2,15 @@ package com.oney.WebRTCModule;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
 import org.webrtc.VideoCapturer;
 
 public abstract class AbstractVideoCaptureController {
-    protected final int targetWidth;
-    protected final int targetHeight;
-    protected final int targetFps;
+    protected int targetWidth;
+    protected int targetHeight;
+    protected int targetFps;
 
     protected int actualWidth;
     protected int actualHeight;
@@ -53,6 +56,16 @@ public abstract class AbstractVideoCaptureController {
 
     public int getFrameRate() {
         return actualFps;
+    }
+
+    public WritableMap getSettings() {
+        WritableMap settings = Arguments.createMap();
+        settings.putString("deviceId", getDeviceId());
+        settings.putString("groupId", "");
+        settings.putInt("height", getHeight());
+        settings.putInt("width", getWidth());
+        settings.putInt("frameRate", getFrameRate());
+        return settings;
     }
 
     public VideoCapturer getVideoCapturer() {

--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -1,8 +1,10 @@
 package com.oney.WebRTCModule;
 
 import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import org.webrtc.VideoCapturer;
@@ -88,6 +90,12 @@ public abstract class AbstractVideoCaptureController {
             return true;
         } catch (InterruptedException e) {
             return false;
+        }
+    }
+
+    public void applyConstraints(ReadableMap constraints, @Nullable Consumer<Exception> onFinishedCallback) {
+        if (onFinishedCallback != null) {
+            onFinishedCallback.accept(new UnsupportedOperationException("This video track does not support applyConstraints."));
         }
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -263,6 +263,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
                 } else {
                     failedDevices.add(name);
                 }
+            }
         }
 
         currentDeviceId = null;

--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -5,8 +5,6 @@ import android.hardware.camera2.CameraManager;
 import android.util.Log;
 import android.util.Pair;
 import androidx.annotation.Nullable;
-
-import androidx.annotation.Nullable;
 import androidx.core.util.Consumer;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -32,7 +30,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
 
     private boolean isFrontFacing;
     @Nullable
-    private String currentDeviceId = null;
+    private String currentDeviceId;
 
     private final Context context;
     private final CameraEnumerator cameraEnumerator;
@@ -315,7 +313,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         List<String> failedDevices = new ArrayList<>();
 
         String cameraName = null;
-        int cameraIndex = 0;
+        int cameraIndex = -1;
         try {
             cameraIndex = Integer.parseInt(deviceId);
             cameraName = deviceNames[cameraIndex];
@@ -376,6 +374,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
                     this.currentDeviceId = String.valueOf(cameraIndex);
                     return new Pair(name, videoCapturer);
                 } else {
+                    Log.d(TAG, message + " failed");
                     failedDevices.add(name);
                 }
             }

--- a/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/CameraCaptureController.java
@@ -82,6 +82,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         return settings;
     }
 
+    @Override
     public void applyConstraints(ReadableMap constraints, @Nullable Consumer<Exception> onFinishedCallback) {
         ReadableMap oldConstraints = this.constraints;
         int oldTargetWidth = this.targetWidth;
@@ -109,7 +110,6 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         String[] deviceNames = cameraEnumerator.getDeviceNames();
         final String deviceId = ReactBridgeUtil.getMapStrValue(constraints, "deviceId");
         final String facingMode = ReactBridgeUtil.getMapStrValue(constraints, "facingMode");
-        final boolean isFrontFacing = facingMode == null || !facingMode.equals("environment");
         int cameraIndex = -1;
         String cameraName = null;
 
@@ -127,6 +127,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         // Otherwise, use facingMode (defaulting to front/user facing).
         if (cameraName == null) {
             cameraIndex = -1;
+            final boolean isFrontFacing = facingMode == null || facingMode.equals("user");
             for (String name : deviceNames) {
                 cameraIndex++;
                 if (cameraEnumerator.isFrontFacing(name) == isFrontFacing) {
@@ -269,7 +270,7 @@ public class CameraCaptureController extends AbstractVideoCaptureController {
         }
 
         // Otherwise, use facingMode (defaulting to front/user facing).
-        final boolean isFrontFacing = facingMode == null || !facingMode.equals("environment");
+        final boolean isFrontFacing = facingMode == null || facingMode.equals("user");
         cameraIndex = -1;
         for (String name : deviceNames) {
             cameraIndex++;

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -234,25 +234,6 @@ class GetUserMediaImpl {
         }
     }
 
-    void switchCamera(String trackId, Promise promise) {
-        TrackPrivate track = tracks.get(trackId);
-        if (track != null && track.videoCaptureController instanceof CameraCaptureController) {
-            CameraCaptureController cameraCaptureController = (CameraCaptureController) track.videoCaptureController;
-            cameraCaptureController.switchCamera(new Consumer<Exception>() {
-                public void accept(Exception e) {
-                    if(e != null) {
-                        promise.reject(e);
-                        return;
-                    }
-
-                    promise.resolve(cameraCaptureController.getSettings());
-                }
-            });
-        } else {
-            promise.reject(new Exception("Camera track not found!"));
-        }
-    }
-
     void applyConstraints(String trackId, ReadableMap constraints, Promise promise) {
         TrackPrivate track = tracks.get(trackId);
         if (track != null && track.videoCaptureController instanceof CameraCaptureController) {
@@ -271,6 +252,7 @@ class GetUserMediaImpl {
             promise.reject(new Exception("Camera track not found!"));
         }
     }
+
     void getDisplayMedia(Promise promise) {
         if (this.displayMediaPromise != null) {
             promise.reject(new RuntimeException("Another operation is pending."));

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -236,16 +236,16 @@ class GetUserMediaImpl {
 
     void applyConstraints(String trackId, ReadableMap constraints, Promise promise) {
         TrackPrivate track = tracks.get(trackId);
-        if (track != null && track.videoCaptureController instanceof CameraCaptureController) {
-            CameraCaptureController cameraCaptureController = (CameraCaptureController) track.videoCaptureController;
-            cameraCaptureController.applyConstraints(constraints, new Consumer<Exception>() {
+        if (track != null && track.videoCaptureController instanceof AbstractVideoCaptureController) {
+            AbstractVideoCaptureController captureController = (AbstractVideoCaptureController) track.videoCaptureController;
+            captureController.applyConstraints(constraints, new Consumer<Exception>() {
                 public void accept(Exception e) {
                     if(e != null) {
                         promise.reject(e);
                         return;
                     }
 
-                    promise.resolve(cameraCaptureController.getSettings());
+                    promise.resolve(captureController.getSettings());
                 }
             });
         } else {

--- a/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
@@ -61,6 +61,11 @@ public class ScreenCaptureController extends AbstractVideoCaptureController {
     }
 
     @Override
+    public String getDeviceId() {
+        return "screen-capture";
+    }
+
+    @Override
     public void dispose() {
         MediaProjectionService.abort(context);
         super.dispose();

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -882,11 +882,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void mediaStreamTrackSwitchCamera(String id) {
+    public void mediaStreamTrackSwitchCamera(String id, Promise promise) {
         ThreadUtils.runOnExecutor(() -> {
             MediaStreamTrack track = getLocalTrack(id);
             if (track != null) {
-                getUserMediaImpl.switchCamera(id);
+                getUserMediaImpl.switchCamera(id, promise);
             }
         });
     }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -882,18 +882,6 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void mediaStreamTrackSwitchCamera(String id, Promise promise) {
-        ThreadUtils.runOnExecutor(() -> {
-            MediaStreamTrack track = getLocalTrack(id);
-            if (track != null) {
-                getUserMediaImpl.switchCamera(id, promise);
-            } else {
-                promise.reject(new Exception("mediaStreamTrackSwitchCamera() could not find track " + id));
-            }
-        });
-    }
-
-    @ReactMethod
     public void mediaStreamTrackApplyConstraints(String id, ReadableMap constraints, Promise promise) {
         ThreadUtils.runOnExecutor(() -> {
             MediaStreamTrack track = getLocalTrack(id);

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -887,6 +887,20 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
             MediaStreamTrack track = getLocalTrack(id);
             if (track != null) {
                 getUserMediaImpl.switchCamera(id, promise);
+            } else {
+                promise.reject(new Exception("mediaStreamTrackSwitchCamera() could not find track " + id));
+            }
+        });
+    }
+
+    @ReactMethod
+    public void mediaStreamTrackApplyConstraints(String id, ReadableMap constraints, Promise promise) {
+        ThreadUtils.runOnExecutor(() -> {
+            MediaStreamTrack track = getLocalTrack(id);
+            if (track != null) {
+                getUserMediaImpl.applyConstraints(id, constraints, promise);
+            } else {
+                promise.reject(new Exception("mediaStreamTrackApplyConstraints() could not find track " + id));
             }
         });
     }

--- a/ios/RCTWebRTC/CaptureController.h
+++ b/ios/RCTWebRTC/CaptureController.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CaptureController : NSObject
 
 @property(nonatomic, strong) id<CapturerEventsDelegate> eventsDelegate;
+@property(nonatomic, copy) NSString* deviceId;
 
 - (void)startCapture;
 - (void)stopCapture;

--- a/ios/RCTWebRTC/CaptureController.h
+++ b/ios/RCTWebRTC/CaptureController.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CaptureController : NSObject
 
 @property(nonatomic, strong) id<CapturerEventsDelegate> eventsDelegate;
-@property(nonatomic, copy) NSString* deviceId;
+@property(nonatomic, copy, nullable) NSString* deviceId;
 
 - (void)startCapture;
 - (void)stopCapture;

--- a/ios/RCTWebRTC/CaptureController.h
+++ b/ios/RCTWebRTC/CaptureController.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startCapture;
 - (void)stopCapture;
+- (NSDictionary *)getSettings;
 
 @end
 

--- a/ios/RCTWebRTC/CaptureController.h
+++ b/ios/RCTWebRTC/CaptureController.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startCapture;
 - (void)stopCapture;
 - (NSDictionary *)getSettings;
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError;
 
 @end
 

--- a/ios/RCTWebRTC/CaptureController.m
+++ b/ios/RCTWebRTC/CaptureController.m
@@ -19,6 +19,12 @@
     };
 }
 
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError {
+    *outError = [NSError errorWithDomain:@"react-native-webrtc"
+                                    code:0
+                                userInfo:@{ NSLocalizedDescriptionKey: @"This video track does not support applyConstraints."}];
+}
+
 @end
 
 #endif

--- a/ios/RCTWebRTC/CaptureController.m
+++ b/ios/RCTWebRTC/CaptureController.m
@@ -12,6 +12,13 @@
     // subclasses needs to override
 }
 
+- (NSDictionary *) getSettings {
+    // subclasses needs to override
+    return @{
+        @"deviceId": self.deviceId
+    };
+}
+
 @end
 
 #endif

--- a/ios/RCTWebRTC/ScreenCaptureController.m
+++ b/ios/RCTWebRTC/ScreenCaptureController.m
@@ -29,6 +29,7 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
     self = [super init];
     if (self) {
         self.capturer = capturer;
+        self.deviceId = @"screen-capture";
     }
 
     return self;

--- a/ios/RCTWebRTC/ScreenCaptureController.m
+++ b/ios/RCTWebRTC/ScreenCaptureController.m
@@ -54,6 +54,13 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
     [self.capturer stopCapture];
 }
 
+- (NSDictionary *)getSettings {
+    return @{
+        @"deviceId": self.deviceId,
+        @"groupId": @"",
+        @"frameRate" : @(30)
+    };
+}
 // MARK: CapturerEventsDelegate Methods
 
 - (void)capturerDidEnd:(RTCVideoCapturer *)capturer {

--- a/ios/RCTWebRTC/VideoCaptureController.h
+++ b/ios/RCTWebRTC/VideoCaptureController.h
@@ -13,7 +13,7 @@
 - (void)startCapture;
 - (void)stopCapture;
 - (void)switchCamera;
-- (void)applyConstraints:(NSDictionary *)constraints;
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError *)outError;
 
 @end
 #endif

--- a/ios/RCTWebRTC/VideoCaptureController.h
+++ b/ios/RCTWebRTC/VideoCaptureController.h
@@ -13,6 +13,7 @@
 - (void)startCapture;
 - (void)stopCapture;
 - (void)switchCamera;
+- (void)applyConstraints:(NSDictionary *)constraints;
 
 @end
 #endif

--- a/ios/RCTWebRTC/VideoCaptureController.h
+++ b/ios/RCTWebRTC/VideoCaptureController.h
@@ -13,7 +13,7 @@
 - (void)startCapture;
 - (void)stopCapture;
 - (void)switchCamera;
-- (void)applyConstraints:(NSDictionary *)constraints error:(NSError *)outError;
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError;
 
 @end
 #endif

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -9,7 +9,6 @@
 @property(nonatomic, strong) RTCCameraVideoCapturer *capturer;
 @property(nonatomic, strong) AVCaptureDeviceFormat *selectedFormat;
 @property(nonatomic, strong) AVCaptureDevice *device;
-@property(nonatomic, copy) NSString *deviceId;
 @property(nonatomic, assign) BOOL running;
 @property(nonatomic, assign) BOOL usingFrontCamera;
 @property(nonatomic, assign) int width;
@@ -67,6 +66,7 @@
         AVCaptureDevicePosition position =
             self.usingFrontCamera ? AVCaptureDevicePositionFront : AVCaptureDevicePositionBack;
         self.device = [self findDeviceForPosition:position];
+        self.deviceId = self.device.uniqueID;
     }
 
     if (!self.device) {

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -104,14 +104,6 @@
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }
 
-- (void)switchCamera {
-    self.usingFrontCamera = !self.usingFrontCamera;
-    self.deviceId = nil;
-    self.device = nil;
-
-    [self startCapture];
-}
-
 - (void)applyConstraints:(NSDictionary *)constraints {
     // Clear device to prepare for starting camera with new constraints.
     self.device = nil;
@@ -188,7 +180,8 @@
         @"groupId": @"",
         @"height" : @(dimensions.height),
         @"width" : @(dimensions.width),
-        @"frameRate" : @(30)
+        @"frameRate" : @(30),
+        @"facingMode" : self.usingFrontCamera ? @"user" : @"environment"; 
     }];
 
     if (self.deviceId) {

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -24,7 +24,7 @@
     if (self) {
         self.capturer = capturer;
         self.running = NO;
-        [self applyConstraints:constraints];
+        [self applyConstraints:constraints error:nil];
     }
 
     return self;
@@ -104,7 +104,7 @@
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }
 
-- (void)applyConstraints:(NSDictionary *)constraints error:(NSError *)outError {
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError **)outError {
     // Clear device to prepare for starting camera with new constraints.
     self.device = nil;
 

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -104,7 +104,7 @@
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }
 
-- (void)applyConstraints:(NSDictionary *)constraints {
+- (void)applyConstraints:(NSDictionary *)constraints error:(NSError *)outError {
     // Clear device to prepare for starting camera with new constraints.
     self.device = nil;
 
@@ -181,7 +181,7 @@
         @"height" : @(dimensions.height),
         @"width" : @(dimensions.width),
         @"frameRate" : @(30),
-        @"facingMode" : self.usingFrontCamera ? @"user" : @"environment"; 
+        @"facingMode" : self.usingFrontCamera ? @"user" : @"environment"
     }];
 
     if (self.deviceId) {

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -24,31 +24,7 @@
     if (self) {
         self.capturer = capturer;
         self.running = NO;
-
-        // Default to the front camera.
-        self.usingFrontCamera = YES;
-
-        self.deviceId = constraints[@"deviceId"];
-        self.width = [constraints[@"width"] intValue];
-        self.height = [constraints[@"height"] intValue];
-        self.frameRate = [constraints[@"frameRate"] intValue];
-
-        id facingMode = constraints[@"facingMode"];
-
-        if (facingMode && [facingMode isKindOfClass:[NSString class]]) {
-            AVCaptureDevicePosition position;
-            if ([facingMode isEqualToString:@"environment"]) {
-                position = AVCaptureDevicePositionBack;
-            } else if ([facingMode isEqualToString:@"user"]) {
-                position = AVCaptureDevicePositionFront;
-            } else {
-                // If the specified facingMode value is not supported, fall back
-                // to the front camera.
-                position = AVCaptureDevicePositionFront;
-            }
-
-            self.usingFrontCamera = position == AVCaptureDevicePositionFront;
-        }
+        [self applyConstraints:constraints];
     }
 
     return self;
@@ -136,6 +112,48 @@
     [self startCapture];
 }
 
+- (void)applyConstraints:(NSDictionary *)constraints {
+    // Default to the front camera.
+    self.usingFrontCamera = YES;
+
+    self.deviceId = constraints[@"deviceId"];
+    self.width = [constraints[@"width"] intValue];
+    self.height = [constraints[@"height"] intValue];
+    self.frameRate = [constraints[@"frameRate"] intValue];
+
+    id facingMode = constraints[@"facingMode"];
+
+    if (facingMode && [facingMode isKindOfClass:[NSString class]]) {
+        AVCaptureDevicePosition position;
+        if ([facingMode isEqualToString:@"environment"]) {
+            position = AVCaptureDevicePositionBack;
+        } else if ([facingMode isEqualToString:@"user"]) {
+            position = AVCaptureDevicePositionFront;
+        } else {
+            // If the specified facingMode value is not supported, fall back
+            // to the front camera.
+            position = AVCaptureDevicePositionFront;
+        }
+
+        self.usingFrontCamera = position == AVCaptureDevicePositionFront;
+    }
+
+    if (self.running) {
+        [self startCapture];
+    }
+}
+
+- (NSDictionary *)getSettings {
+    AVCaptureDeviceFormat *format = vcc.selectedFormat;
+    CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
+    return @{
+        @"deviceId": self.deviceId,
+        @"groupId": @"",
+        @"height" : @(dimensions.height),
+        @"width" : @(dimensions.width),
+        @"frameRate" : @(30)
+    };
+}
 #pragma mark NSKeyValueObserving
 
 - (void)observeValueForKeyPath:(NSString *)keyPath

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -403,30 +403,6 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled : (nonnull NSNumber *)pcId : (nonnu
 #endif
 }
 
-RCT_EXPORT_METHOD(mediaStreamTrackSwitchCamera : (nonnull NSString *)trackID resolver: (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject) {
-#if TARGET_OS_TV
-    reject(@"unsupported_platform", @"tvOS is not supported", nil);
-    return;
-#else
-    RTCMediaStreamTrack *track = self.localTracks[trackID];
-    if (track) {
-        if ([track.kind isEqualToString:@"video"]) {
-            RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-            VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-            [vcc switchCamera];
-
-            resolve([vcc getSettings]);
-        } else {
-            RCTLogWarn(@"mediaStreamTrackSwitchCamera() track is not video");
-            reject(@"E_INVALID", @"Can't switch camera on audio tracks", nil);
-        }
-    } else {
-        RCTLogWarn(@"mediaStreamTrackSwitchCamera() track is null");
-        reject(@"E_INVALID", @"Could not get track", nil);
-    }
-#endif
-}
-
 RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints : (nonnull NSString *)trackID : (NSDictionary *)constraints : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
 #if TARGET_OS_TV
     reject(@"unsupported_platform", @"tvOS is not supported", nil);
@@ -441,11 +417,11 @@ RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints : (nonnull NSString *)trackID
 
             resolve([vcc getSettings]);
         } else {
-            RCTLogWarn(@"mediaStreamTrackSwitchCamera() track is not video");
-            reject(@"E_INVALID", @"Can't switch camera on audio tracks", nil);
+            RCTLogWarn(@"mediaStreamTrackApplyConstraints() track is not video");
+            reject(@"E_INVALID", @"Can't apply constraints on audio tracks", nil);
         }
     } else {
-        RCTLogWarn(@"mediaStreamTrackSwitchCamera() track is null");
+        RCTLogWarn(@"mediaStreamTrackApplyConstraints() track is null");
         reject(@"E_INVALID", @"Could not get track", nil);
     }
 #endif

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -413,9 +413,13 @@ RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints : (nonnull NSString *)trackID
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
             VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-            [vcc applyConstraints:constraints];
-
-            resolve([vcc getSettings]);
+            NSError* error = nil;
+            [vcc applyConstraints:constraints error:&error];
+            if (error) {
+                reject(@"E_INVALID", error.localizedDescription, error);
+            } else {
+                resolve([vcc getSettings]);
+            }
         } else {
             RCTLogWarn(@"mediaStreamTrackApplyConstraints() track is not video");
             reject(@"E_INVALID", @"Can't apply constraints on audio tracks", nil);

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -412,13 +412,15 @@ RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints : (nonnull NSString *)trackID
     if (track) {
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-            VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-            NSError* error = nil;
-            [vcc applyConstraints:constraints error:&error];
-            if (error) {
-                reject(@"E_INVALID", error.localizedDescription, error);
-            } else {
-                resolve([vcc getSettings]);
+            if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
+                CaptureController *vcc = (CaptureController *)videoTrack.captureController;
+                NSError* error = nil;
+                [vcc applyConstraints:constraints error:&error];
+                if (error) {
+                    reject(@"E_INVALID", error.localizedDescription, error);
+                } else {
+                    resolve([vcc getSettings]);
+                }
             }
         } else {
             RCTLogWarn(@"mediaStreamTrackApplyConstraints() track is not video");

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -78,7 +78,7 @@
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
             if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
-                settings = [vcc getSettings];
+                settings = [videoTrack.captureController getSettings];
             }
         } else if ([track.kind isEqualToString:@"audio"]) {
             settings = @{
@@ -237,7 +237,7 @@ RCT_EXPORT_METHOD(getUserMedia
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
             if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
-                settings = [vcc getSettings];
+                settings = [videoTrack.captureController getSettings];
             }
         } else if ([track.kind isEqualToString:@"audio"]) {
             settings = @{
@@ -414,17 +414,8 @@ RCT_EXPORT_METHOD(mediaStreamTrackSwitchCamera : (nonnull NSString *)trackID res
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
             VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
             [vcc switchCamera];
-            AVCaptureDeviceFormat *format = vcc.selectedFormat;
-            CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
 
-            NSDictionary *settings = @{
-                @"deviceId": vcc.deviceId,
-                @"groupId": @"",
-                @"height" : @(dimensions.height),
-                @"width" : @(dimensions.width),
-                @"frameRate" : @(30)
-            };
-            resolve(settings);
+            resolve([vcc getSettings]);
         } else {
             RCTLogWarn(@"mediaStreamTrackSwitchCamera() track is not video");
             reject(@"E_INVALID", @"Can't switch camera on audio tracks", nil);
@@ -446,18 +437,9 @@ RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints : (nonnull NSString *)trackID
         if ([track.kind isEqualToString:@"video"]) {
             RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
             VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-            [vcc switchCamera];
-            AVCaptureDeviceFormat *format = vcc.selectedFormat;
-            CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
+            [vcc applyConstraints:constraints];
 
-            NSDictionary *settings = @{
-                @"deviceId": vcc.deviceId,
-                @"groupId": @"",
-                @"height" : @(dimensions.height),
-                @"width" : @(dimensions.width),
-                @"frameRate" : @(30)
-            };
-            resolve(settings);
+            resolve([vcc getSettings]);
         } else {
             RCTLogWarn(@"mediaStreamTrackSwitchCamera() track is not video");
             reject(@"E_INVALID", @"Can't switch camera on audio tracks", nil);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings 0 . && tsc --noEmit",
+    "lintfix": "eslint --max-warnings 0 --fix . && tsc --noEmit",
     "prepare": "husky install && bob build",
     "format": "tools/format.sh"
   },

--- a/src/Constraints.ts
+++ b/src/Constraints.ts
@@ -1,0 +1,21 @@
+
+export type MediaTrackConstraints = {
+    width?: ConstrainNumber;
+    height?: ConstrainNumber;
+    frameRate?: ConstrainNumber;
+    facingMode?: ConstrainString;
+    deviceId?: ConstrainString;
+    groupId?: ConstrainString;
+}
+
+type ConstrainNumber = number | {
+    exact?: number,
+    ideal?: number,
+    max?: number,
+    min?: number,
+}
+
+type ConstrainString = string | {
+    exact?: string,
+    ideal?: string,
+}

--- a/src/MediaDevices.ts
+++ b/src/MediaDevices.ts
@@ -2,7 +2,7 @@ import { EventTarget, Event, defineEventAttribute } from 'event-target-shim/inde
 import { NativeModules } from 'react-native';
 
 import getDisplayMedia from './getDisplayMedia';
-import getUserMedia from './getUserMedia';
+import getUserMedia, { Constraints } from './getUserMedia';
 
 const { WebRTCModule } = NativeModules;
 
@@ -37,7 +37,7 @@ class MediaDevices extends EventTarget<MediaDevicesEventMap> {
      * @param {*} constraints
      * @returns {Promise}
      */
-    getUserMedia(constraints) {
+    getUserMedia(constraints: Constraints) {
         return getUserMedia(constraints);
     }
 }

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -98,7 +98,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
      * This is how the reference application (AppRTCMobile) implements camera
      * switching.
      */
-    _switchCamera(): void {
+    async _switchCamera(): Promise<void> {
         if (this.remote) {
             throw new Error('Not implemented for remote tracks');
         }
@@ -107,7 +107,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
             throw new Error('Only implemented for video tracks');
         }
 
-        WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
+        this._settings = await WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
     }
 
     _setVideoEffect(name:string) {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -98,7 +98,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
      * This is how the reference application (AppRTCMobile) implements camera
      * switching.
      */
-    async _switchCamera(): Promise<void> {
+    _switchCamera(): void {
         if (this.remote) {
             throw new Error('Not implemented for remote tracks');
         }
@@ -107,7 +107,10 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
             throw new Error('Only implemented for video tracks');
         }
 
-        this._settings = await WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
+        let switchImpl = async () => {
+            this._settings = await WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
+        };
+        switchImpl();
     }
 
     _setVideoEffect(name:string) {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -165,11 +165,8 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
             video = constraints;
         }
 
-        let normalized = normalizeConstraints({
-            video
-        });
+        let normalized = normalizeConstraints({ video });
 
-        console.log("apply constraints normalized: ", normalized.video);
         this._settings = await WebRTCModule.mediaStreamTrackApplyConstraints(this.id, normalized.video);
     }
 

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -97,6 +97,8 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
      *
      * This is how the reference application (AppRTCMobile) implements camera
      * switching.
+     * 
+     * @deprecated Use applyConstraints instead.
      */
     _switchCamera(): void {
         if (this.remote) {
@@ -154,6 +156,16 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
         WebRTCModule.mediaStreamTrackSetVolume(this.remote ? this._peerConnectionId : -1, this.id, volume);
     }
 
+    /**
+     * Applies a new set of constraints to the track.
+     * 
+     * @param constraints An object listing the constraints
+     * to apply to the track's constrainable properties; any existing 
+     * constraints are replaced with the new values specified, and any 
+     * constrainable properties not included are restored to their default 
+     * constraints. If this parameter is omitted, all currently set custom 
+     * constraints are cleared.
+     */
     async applyConstraints(constraints?: object): Promise<void> {
         if (this.kind !== 'video') {
             throw new Error('Only implemented for video tracks');

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -97,7 +97,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
      *
      * This is how the reference application (AppRTCMobile) implements camera
      * switching.
-     * 
+     *
      * @deprecated Use applyConstraints instead.
      */
     _switchCamera(): void {
@@ -158,12 +158,12 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
 
     /**
      * Applies a new set of constraints to the track.
-     * 
+     *
      * @param constraints An object listing the constraints
-     * to apply to the track's constrainable properties; any existing 
-     * constraints are replaced with the new values specified, and any 
-     * constrainable properties not included are restored to their default 
-     * constraints. If this parameter is omitted, all currently set custom 
+     * to apply to the track's constrainable properties; any existing
+     * constraints are replaced with the new values specified, and any
+     * constrainable properties not included are restored to their default
+     * constraints. If this parameter is omitted, all currently set custom
      * constraints are cleared.
      */
     async applyConstraints(constraints?: object): Promise<void> {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -120,15 +120,10 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
         }
 
         const constraints = deepClone(this._settings);
-
         delete constraints.deviceId;
         constraints.facingMode = this._settings.facingMode === 'user' ? 'environment' : 'user';
 
-        const switchImpl = async () => {
-            await this.applyConstraints(constraints);
-        };
-
-        switchImpl();
+        this.applyConstraints(constraints);
     }
 
     _setVideoEffect(name:string) {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -171,15 +171,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
             throw new Error('Only implemented for video tracks');
         }
 
-        let video: boolean | object;
-
-        if (constraints === undefined) {
-            video = true;
-        } else {
-            video = constraints;
-        }
-
-        const normalized = normalizeConstraints({ video });
+        const normalized = normalizeConstraints({ video: constraints ?? true });
 
         this._settings = await WebRTCModule.mediaStreamTrackApplyConstraints(this.id, normalized.video);
     }

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -3,7 +3,7 @@ import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';
 import Logger from './Logger';
-import { deepClone } from './RTCUtil';
+import { deepClone, normalizeConstraints } from './RTCUtil';
 
 const log = new Logger('pc');
 const { WebRTCModule } = NativeModules;
@@ -153,8 +153,24 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
         WebRTCModule.mediaStreamTrackSetVolume(this.remote ? this._peerConnectionId : -1, this.id, volume);
     }
 
-    applyConstraints(): never {
-        throw new Error('Not implemented.');
+    async applyConstraints(constraints?: object): Promise<void> {
+        if (this.kind !== 'video') {
+            throw new Error('Only implemented for video tracks');
+        }
+
+        let video: boolean | object;
+        if(constraints === undefined) {
+            video = true;
+        } else {
+            video = constraints;
+        }
+
+        let normalized = normalizeConstraints({
+            video
+        });
+
+        console.log("apply constraints normalized: ", normalized.video);
+        this._settings = await WebRTCModule.mediaStreamTrackApplyConstraints(this.id, normalized.video);
     }
 
     clone(): never {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -120,6 +120,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
         }
 
         const constraints = deepClone(this._settings);
+
         delete constraints.deviceId;
         constraints.facingMode = this._settings.facingMode === 'user' ? 'environment' : 'user';
 

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -1,10 +1,10 @@
 import { EventTarget, Event, defineEventAttribute } from 'event-target-shim/index';
 import { NativeModules } from 'react-native';
 
+import { MediaTrackConstraints } from './Constraints';
 import { addListener, removeListener } from './EventEmitter';
 import Logger from './Logger';
 import { deepClone, normalizeConstraints } from './RTCUtil';
-import { MediaTrackConstraints } from './Constraints';
 
 const log = new Logger('pc');
 const { WebRTCModule } = NativeModules;
@@ -119,9 +119,10 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
             throw new Error('Only implemented for video tracks');
         }
 
-        let constraints = deepClone(this._settings)
+        const constraints = deepClone(this._settings);
+
         delete constraints.deviceId;
-        constraints.facingMode = this._settings.facingMode == "user" ? "environment" : "user";
+        constraints.facingMode = this._settings.facingMode === 'user' ? 'environment' : 'user';
 
         const switchImpl = async () => {
             await this.applyConstraints(constraints);
@@ -188,7 +189,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
         const normalized = normalizeConstraints({ video: constraints ?? true });
 
         this._settings = await WebRTCModule.mediaStreamTrackApplyConstraints(this.id, normalized.video);
-        this._constraints = constraints ?? {}
+        this._constraints = constraints ?? {};
     }
 
     clone(): never {

--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -107,9 +107,10 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
             throw new Error('Only implemented for video tracks');
         }
 
-        let switchImpl = async () => {
+        const switchImpl = async () => {
             this._settings = await WebRTCModule.mediaStreamTrackSwitchCamera(this.id);
         };
+
         switchImpl();
     }
 
@@ -159,13 +160,14 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
         }
 
         let video: boolean | object;
-        if(constraints === undefined) {
+
+        if (constraints === undefined) {
             video = true;
         } else {
             video = constraints;
         }
 
-        let normalized = normalizeConstraints({ video });
+        const normalized = normalizeConstraints({ video });
 
         this._settings = await WebRTCModule.mediaStreamTrackApplyConstraints(this.id, normalized.video);
     }

--- a/src/getUserMedia.ts
+++ b/src/getUserMedia.ts
@@ -6,12 +6,13 @@ import MediaStream from './MediaStream';
 import MediaStreamError from './MediaStreamError';
 import permissions from './Permissions';
 import * as RTCUtil from './RTCUtil';
+import { MediaTrackConstraints } from './Constraints';
 
 const { WebRTCModule } = NativeModules;
 
-interface Constraints {
-    audio?: boolean | object;
-    video?: boolean | object;
+export interface Constraints {
+    audio?: boolean | MediaTrackConstraints;
+    video?: boolean | MediaTrackConstraints;
 }
 
 export default function getUserMedia(constraints: Constraints = {}): Promise<MediaStream> {

--- a/src/getUserMedia.ts
+++ b/src/getUserMedia.ts
@@ -2,11 +2,11 @@
 import { NativeModules } from 'react-native';
 
 
+import { MediaTrackConstraints } from './Constraints';
 import MediaStream from './MediaStream';
 import MediaStreamError from './MediaStreamError';
 import permissions from './Permissions';
 import * as RTCUtil from './RTCUtil';
-import { MediaTrackConstraints } from './Constraints';
 
 const { WebRTCModule } = NativeModules;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { setupNativeEvents } from './EventEmitter';
 import Logger from './Logger';
 import mediaDevices from './MediaDevices';
 import MediaStream from './MediaStream';
-import MediaStreamTrack from './MediaStreamTrack';
+import MediaStreamTrack, {type MediaTrackSettings} from './MediaStreamTrack';
 import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import permissions from './Permissions';
 import RTCAudioSession from './RTCAudioSession';
@@ -44,6 +44,7 @@ export {
     RTCAudioSession,
     MediaStream,
     MediaStreamTrack,
+    type MediaTrackSettings,
     mediaDevices,
     permissions,
     registerGlobals

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { setupNativeEvents } from './EventEmitter';
 import Logger from './Logger';
 import mediaDevices from './MediaDevices';
 import MediaStream from './MediaStream';
-import MediaStreamTrack, {type MediaTrackSettings} from './MediaStreamTrack';
+import MediaStreamTrack, { type MediaTrackSettings } from './MediaStreamTrack';
 import MediaStreamTrackEvent from './MediaStreamTrackEvent';
 import permissions from './Permissions';
 import RTCAudioSession from './RTCAudioSession';


### PR DESCRIPTION
Adds [missing deviceId/groupId values](https://w3c.github.io/mediacapture-main/#media-track-settings) to the settings map sent back for MediaStreamTracks.

Additionally changes the `_switchCamera` method to an async method, so that it can get the final settings of the camera when done switching.

The one thing that's missing is iOS audio track deviceId/groupId. Can't find any way to associate the available input mics to the one actually in use by WebRTC. Can change `enumerateDevices` to send back a dummy deviceId like we do on Android, since iOS webrtc doesn't really do anything with audio device ids either, but I'm not sure if this might adversely affect anybody by this change.