### PR TITLE
android: don't use minSdkVersion set by app

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
     buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 24)
+        minSdkVersion 24
         targetSdkVersion safeExtGet('targetSdkVersion', 24)
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Client apps could set their minSdkVersion to a lower version (RN 0.73 defaults to 21, and RN 0.74 is at 23), unknowingly sidestepping the minSdkVersion restriction.

They can still explicitly override it by adding the following to their app's AndroidManifest.xml:
```
<uses-sdk tools:overrideLibrary="com.oney.WebRTCModule"/>
```