### PR TITLE
ios: add background camera access option

### DIFF
--- a/ios/RCTWebRTC/VideoCaptureController.h
+++ b/ios/RCTWebRTC/VideoCaptureController.h
@@ -8,6 +8,7 @@
 @interface VideoCaptureController : CaptureController
 @property(nonatomic, readonly, strong) AVCaptureDeviceFormat *selectedFormat;
 @property(nonatomic, readonly, assign) int frameRate;
+@property(nonatomic, assign) BOOL enableMultitaskingCameraAccess;
 
 - (instancetype)initWithCapturer:(RTCCameraVideoCapturer *)capturer andConstraints:(NSDictionary *)constraints;
 - (void)startCapture;

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -62,6 +62,19 @@
 
     self.selectedFormat = format;
 
+    AVCaptureSession * session = self.capturer.captureSession;
+    if (@available(iOS 16.0, *)) {
+        if(session.multitaskingCameraAccessEnabled != self.enableMultitaskingCameraAccess) {
+            [session beginConfiguration];
+            if(self.enableMultitaskingCameraAccess && session.isMultitaskingCameraAccessSupported) {
+                [session setMultitaskingCameraAccessEnabled:YES];
+            } else {
+                [session setMultitaskingCameraAccessEnabled:NO];
+            }
+            [session commitConfiguration];
+        }
+    }
+
     RCTLog(@"[VideoCaptureController] Capture will start");
 
     // Starting the capture happens on another thread. Wait for it.

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -6,6 +6,7 @@
 #import <WebRTC/RTCVideoTrack.h>
 
 #import "RTCMediaStreamTrack+React.h"
+#import "WebRTCModuleOptions.h"
 #import "WebRTCModule+RTCMediaStream.h"
 #import "WebRTCModule+RTCPeerConnection.h"
 
@@ -118,6 +119,7 @@
     RTCCameraVideoCapturer *videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
     VideoCaptureController *videoCaptureController =
         [[VideoCaptureController alloc] initWithCapturer:videoCapturer andConstraints:constraints[@"video"]];
+    videoCaptureController.enableMultitaskingCameraAccess = [WebRTCModuleOptions sharedInstance].enableMultitaskingCameraAccess;
     videoTrack.captureController = videoCaptureController;
     [videoCaptureController startCapture];
 #endif

--- a/ios/RCTWebRTC/WebRTCModuleOptions.h
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) id<RTCAudioDevice> audioDevice;
 @property(nonatomic, strong, nullable) NSDictionary *fieldTrials;
 @property(nonatomic, assign) RTCLoggingSeverity loggingSeverity;
+@property(nonatomic, assign) BOOL enableMultitaskingCameraAccess;
 
 #pragma mark - This class is a singleton
 


### PR DESCRIPTION
Added flags to the options. Tested in combination with the iOS PIP PR to see the camera working in the background with voip background mode (doesn't seem to work without PIP, or at least needs something else to keep the app alive in the background, CallKit would probably work).

Caveats: needs iOS 18+ and the [conditions noted here](https://developer.apple.com/documentation/avfoundation/avcapturesession/4013228-multitaskingcameraaccesssupporte?language=objc).