### PR TITLE
android: add libwebrtc consumer proguard rules

### DIFF
--- a/Documentation/AndroidInstallation.md
+++ b/Documentation/AndroidInstallation.md
@@ -64,14 +64,6 @@ compileOptions {
 }
 ```
 
-## R8/ProGuard Support
-
-In `android/app/proguard-rules.pro` add the following on a new line.
-
-```proguard
--keep class org.webrtc.** { *; }
-```
-
 ## Fatal Exception: java.lang.UnsatisfiedLinkError
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ android {
         targetSdkVersion safeExtGet('targetSdkVersion', 24)
         versionCode 1
         versionName "1.0"
+        consumerProguardFiles 'consumer-rules.pro'
     }
 
     // WebRTC requires Java 8 features

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,2 @@
+# WebRTC
+-keep class org.webrtc.** { *; }


### PR DESCRIPTION
Addresses #590 so that downstream consumers don't have to add their own rule (which can be annoying in Expo environments).

----

~~Needs testing. This works elsewhere for AARs, but I need to verify that it works in the react-native build system. Will get to it this weekish, but putting this up here for now.~~

Tested, works fine.