### PR TITLE
Improve type safety in RTCPeerConnection's getSenders and getReceivers

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -535,13 +535,11 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
     }
 
     getSenders(): RTCRtpSender[] {
-        // @ts-ignore
-        return this._transceivers.map(e => !e.transceiver.stopped && e.transceiver.sender).filter(Boolean);
+        return this._transceivers.filter(e => !e.transceiver.stopped).map(e => e.transceiver.sender);
     }
 
     getReceivers(): RTCRtpReceiver[] {
-        // @ts-ignore
-        return this._transceivers.map(e => !e.transceiver.stopped && e.transceiver.receiver).filter(Boolean);
+        return this._transceivers.filter(e => !e.transceiver.stopped).map(e => e.transceiver.receiver);
     }
 
     close(): void {


### PR DESCRIPTION
- This PR changes the approach to first filter `stopped === false` transceivers and then map to sender/receiver. This enhances code readability and is more intuitive.
- Additionally, type safety is improved and the `@ts-ignore` comments could be removed.

Please let me know if there are any issues with this approach.




--------------------- previous commit
pc: filter out stopped transceivers

For getSenders / getReceivers they should always be filtered:
https://www.w3.org/TR/webrtc/#dom-peerconnection-getsenders

For getTransceivers, when setting an answer description they should
be filtered out if stopped:
https://w3c.github.io/webrtc-pc/#set-the-session-description (6, 12).