### PR TITLE
improve createOffer types and removed mandatory key from sessionConstraints in docs

### DIFF
--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -232,11 +232,9 @@ That will allow you to enable and disable video streams on demand while a call i
 
 ```javascript
 let sessionConstraints = {
-	mandatory: {
-		OfferToReceiveAudio: true,
-		OfferToReceiveVideo: true,
-		VoiceActivityDetection: true
-	}
+	offerToReceiveAudio: true,
+	offerToReceiveVideo: true,
+	voiceActivityDetection: true
 };
 ```
 

--- a/Documentation/CallGuide.md
+++ b/Documentation/CallGuide.md
@@ -143,11 +143,9 @@ So you can now start creating an offer which then needs sending send off to the 
 
 ```javascript
 let sessionConstraints = {
-	mandatory: {
-		OfferToReceiveAudio: true,
-		OfferToReceiveVideo: true,
-		VoiceActivityDetection: true
-	}
+	offerToReceiveAudio: true,
+	offerToReceiveVideo: true,
+	voiceActivityDetection: true
 };
 
 try {

--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -18,6 +18,7 @@ import RTCRtpTransceiver from './RTCRtpTransceiver';
 import RTCSessionDescription, { RTCSessionDescriptionInit } from './RTCSessionDescription';
 import RTCTrackEvent from './RTCTrackEvent';
 import * as RTCUtil from './RTCUtil';
+import { RTCOfferOptions } from './RTCUtil';
 
 const log = new Logger('pc');
 const { WebRTCModule } = NativeModules;
@@ -132,7 +133,7 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
         log.debug(`${this._pcId} ctor`);
     }
 
-    async createOffer(options) {
+    async createOffer(options?:RTCOfferOptions) {
         log.debug(`${this._pcId} createOffer`);
 
         const {

--- a/src/RTCUtil.ts
+++ b/src/RTCUtil.ts
@@ -12,6 +12,13 @@ const FACING_MODES = [ 'user', 'environment' ];
 
 const ASPECT_RATIO = 16 / 9;
 
+export type RTCOfferOptions  = {
+    iceRestart?:boolean;
+    offerToReceiveAudio?: boolean;
+    offerToReceiveVideo?: boolean;
+    voiceActivityDetection?:boolean
+};
+
 const STANDARD_OFFER_OPTIONS = {
     icerestart: 'IceRestart',
     offertoreceiveaudio: 'OfferToReceiveAudio',
@@ -157,10 +164,10 @@ export function isSdpTypeValid(type: string): boolean {
  * @param options - user supplied options
  * @return Normalized options
  */
-export function normalizeOfferOptions(options: object = {}): object {
-    const newOptions = {};
+export function normalizeOfferOptions(options?: RTCOfferOptions) {
+    const newOptions: Record<string,string> = {};
 
-    if (!options) {
+    if (typeof options !== 'object') {
         return newOptions;
     }
 


### PR DESCRIPTION
1. Removed mandatory key from sessionConstraints in docs, as the code directly reads from sessionConstraints, not from sessionConstraints.mandatory.
2. Align createOffer case as per web standard [w3 docs](https://www.w3.org/TR/webrtc/#dom-rtcofferoptions)
3. Added types to `createOffer`
4. Used typeof options !== 'object' instead of !{} while normalizing offer options, as !{} always evaluates to false