### PR TITLE
package.json: move husky to postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "lint": "eslint --max-warnings 0 . && tsc --noEmit",
     "lintfix": "eslint --max-warnings 0 --fix . && tsc --noEmit",
-    "prepare": "husky install && bob build",
+    "postinstall": "husky install",
+    "prepare": "bob build",
     "format": "tools/format.sh"
   },
   "bugs": {


### PR DESCRIPTION
So `prepare` is pretty similar to `postinstall` but there are some differences, namely:

> NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

So the existing husky command has some problems running if you're trying to `npm install` a forked version of react-native-webrtc. Moving it to `postinstall` causes the behavior to be identical for developers working on this repo while allowing forked versions to be able to run the `prepare` script correctly.