### PR TITLE
simplified version of Android PIP support

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -1,16 +1,24 @@
 package com.oney.WebRTCModule;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.oney.WebRTCModule.pictureInPicture.PictureInPictureController;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
-public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
+public class RTCVideoViewManager extends ViewGroupManager<WebRTCView> {
     private static final String REACT_CLASS = "RTCVideoView";
+
+    public final int COMMAND_ENTER_PIP = 1;
 
     @Override
     public String getName() {
@@ -87,6 +95,17 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
         view.setOnDimensionsChange(onDimensionsChange);
     }
 
+    /**
+     * Sets the desired PIP options.
+     *
+     * @param view The {@code WebRTCView} on which the callback is to be set.
+     * @param map The PIP options.
+     */
+    @ReactProp(name = "pictureInPictureOptions")
+    public void setPIPOptions(WebRTCView view, ReadableMap map) {
+        view.setPIPOptions(map);
+    }
+
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         Map<String, Object> eventTypeConstants = new HashMap<>();
@@ -94,5 +113,30 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
         dimensionsChangeEvent.put("registrationName", "onDimensionsChange");
         eventTypeConstants.put("onDimensionsChange", dimensionsChangeEvent);
         return eventTypeConstants;
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Integer> getCommandsMap() {
+        return MapBuilder.of("startAndroidPIP", COMMAND_ENTER_PIP);
+    }
+
+    @Override
+    public void receiveCommand(@NonNull WebRTCView view, String commandId, @Nullable ReadableArray args) {
+        super.receiveCommand(view, commandId, args);
+        int commandIdInt = Integer.parseInt(commandId);
+
+        if (commandIdInt == COMMAND_ENTER_PIP) {
+            view.enterPictureInPicture();
+        }
+    }
+
+    @Override
+    public Map getExportedCustomBubblingEventTypeConstants() {
+        return MapBuilder.builder()
+                .put(PictureInPictureController.onPictureInPictureChangeEventName,
+                        MapBuilder.of("phasedRegistrationNames",
+                                MapBuilder.of("bubbled", PictureInPictureController.onPictureInPictureChangeEventName)))
+                .build();
     }
 }

--- a/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureController.java
@@ -1,0 +1,188 @@
+package com.oney.WebRTCModule.pictureInPicture;
+
+import android.app.Activity;
+import android.util.Rational;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+import java.util.ArrayList;
+
+public class PictureInPictureController implements PictureInPictureHelperListener {
+    @Nullable
+    ReactContext reactContext;
+
+    @Nullable
+    Activity currentActivity;
+
+    @Nullable
+    ViewGroup rootViewGroup;
+
+    PictureInPictureDelegate delegate;
+
+    /**
+     * Helper tag to safely attach and detach PictureInPictureHelperFragment
+     */
+    @Nullable
+    private String pictureInPictureHelperTag;
+
+    /**
+     * Save the rootView's children original visibility state.
+     */
+    private final ArrayList<Integer> rootViewChildrenOriginalVisibility = new ArrayList<>();
+
+    /**
+     * Event name to send to onPictureInPictureChange callback.
+     */
+    public static String onPictureInPictureChangeEventName = "onPictureInPictureChange";
+
+    public PictureInPictureController(PictureInPictureDelegate delegate) {
+        this.delegate = delegate;
+        this.reactContext = (ReactContext) delegate.getContext();
+        this.currentActivity = reactContext.getCurrentActivity();
+
+        if (this.currentActivity != null) {
+            this.rootViewGroup = this.currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
+        }
+
+        attachPictureInPictureHelperFragment();
+    }
+
+    public void setPIPOptions(ReadableMap map) {
+        boolean startAutomatically = true;
+
+        if (map.hasKey("startAutomatically")) {
+            startAutomatically = map.getBoolean("startAutomatically");
+        }
+
+        setAutoEnter(startAutomatically);
+        setPreferredSize(map.getMap("preferredSize"));
+    }
+
+    void setAutoEnter(Boolean autoEnter) {
+        PictureInPictureUtils.applyAutoEnter(currentActivity, autoEnter);
+    }
+
+    void setDefaultAspectRatio() {
+        PictureInPictureUtils.applyAspectRatio(currentActivity, new Rational(150, 200));
+    }
+
+    void setPreferredSize(@Nullable ReadableMap size) {
+        if (size == null) {
+            setDefaultAspectRatio();
+            return;
+        }
+
+        if (!size.hasKey("width") || size.isNull("width") || !size.hasKey("height") || size.isNull("height")) {
+            setDefaultAspectRatio();
+            return;
+        }
+
+        Rational aspectRatio = new Rational(size.getInt("width"), size.getInt("height"));
+
+        if (aspectRatio.isNaN()) {
+            setDefaultAspectRatio();
+            return;
+        }
+
+        PictureInPictureUtils.applyAspectRatio(currentActivity, aspectRatio);
+    }
+
+    public void enterPictureInPicture() {
+        if (currentActivity == null) return;
+        PictureInPictureUtils.safeEnterPictureInPicture(currentActivity);
+    }
+
+    protected void layoutForPipEnter() {
+        if (rootViewGroup == null) return;
+
+        delegate.getVideoContainer().removeView(delegate.getVideoRenderer());
+
+        for (int i = 0; i < rootViewGroup.getChildCount(); i++) {
+            View child = rootViewGroup.getChildAt(i);
+            if (child != delegate.getVideoRenderer()) {
+                rootViewChildrenOriginalVisibility.add(child.getVisibility());
+                child.setVisibility(View.GONE);
+            }
+        }
+
+        rootViewGroup.addView(delegate.getVideoRenderer(),
+                new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+    }
+
+    private void layoutForPipExit() {
+        if (rootViewGroup == null) return;
+
+        rootViewGroup.removeView(delegate.getVideoRenderer());
+
+        for (int i = 0; i < rootViewGroup.getChildCount(); i++) {
+            rootViewGroup.getChildAt(i).setVisibility(rootViewChildrenOriginalVisibility.get(i));
+        }
+
+        rootViewChildrenOriginalVisibility.clear();
+
+        delegate.getVideoContainer().addView(delegate.getVideoRenderer(),
+                new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        delegate.requestVideoRenderUpdate();
+    }
+
+    public void attachPictureInPictureHelperFragment() {
+        if (currentActivity == null) return;
+
+        if (currentActivity instanceof FragmentActivity) {
+            FragmentActivity fragmentActivity = (FragmentActivity) currentActivity;
+            PictureInPictureHelperFragment fragment = new PictureInPictureHelperFragment();
+            pictureInPictureHelperTag = fragment.id;
+            fragment.setListener(this);
+            fragmentActivity.getSupportFragmentManager().beginTransaction().add(fragment, fragment.id).commit();
+        }
+    }
+
+    public void detachPictureInPictureHelperFragment() {
+        if (currentActivity == null) return;
+
+        if (currentActivity instanceof FragmentActivity) {
+            FragmentActivity fragmentActivity = (FragmentActivity) currentActivity;
+            Fragment fragment =
+                    fragmentActivity.getSupportFragmentManager().findFragmentByTag(pictureInPictureHelperTag);
+            if (fragment != null) {
+                fragmentActivity.getSupportFragmentManager()
+                        .beginTransaction()
+                        .remove(fragment)
+                        .commitAllowingStateLoss();
+            }
+        }
+        PictureInPictureUtils.applyAutoEnter(currentActivity, false);
+    }
+
+    private void sendPictureInPictureModeChangeEvent(Boolean isInPictureInPictureMode) {
+        if (reactContext == null) return;
+
+        WritableMap event = Arguments.createMap();
+        event.putBoolean("isInPictureInPicture", isInPictureInPictureMode);
+
+        reactContext.getJSModule(RCTEventEmitter.class)
+                .receiveEvent(delegate.getVideoContainer().getId(), onPictureInPictureChangeEventName, event);
+    }
+
+    @Override
+    public void onPictureInPictureModeChange(Boolean isInPictureInPictureMode) {
+        sendPictureInPictureModeChangeEvent(isInPictureInPictureMode);
+
+        if (isInPictureInPictureMode) {
+            layoutForPipEnter();
+        } else {
+            layoutForPipExit();
+        }
+    }
+}

--- a/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureDelegate.java
+++ b/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureDelegate.java
@@ -1,0 +1,12 @@
+package com.oney.WebRTCModule.pictureInPicture;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+
+public interface PictureInPictureDelegate {
+    View getVideoRenderer();
+    ViewGroup getVideoContainer();
+    void requestVideoRenderUpdate();
+    Context getContext();
+}

--- a/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureHelperFragment.java
+++ b/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureHelperFragment.java
@@ -1,0 +1,30 @@
+
+package com.oney.WebRTCModule.pictureInPicture;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import java.util.UUID;
+
+public class PictureInPictureHelperFragment extends Fragment {
+    String id = "PictureInPictureHelperFragment" + UUID.randomUUID().toString();
+
+    @Nullable
+    private PictureInPictureHelperListener listener;
+
+    void setListener(PictureInPictureHelperListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode);
+        if (listener != null) {
+            listener.onPictureInPictureModeChange(isInPictureInPictureMode);
+        }
+    }
+}
+
+interface PictureInPictureHelperListener {
+    void onPictureInPictureModeChange(Boolean isInPictureInPictureMode);
+}

--- a/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureUtils.java
+++ b/android/src/main/java/com/oney/WebRTCModule/pictureInPicture/PictureInPictureUtils.java
@@ -1,0 +1,107 @@
+package com.oney.WebRTCModule.pictureInPicture;
+
+import android.app.Activity;
+import android.app.PictureInPictureParams;
+import android.content.pm.PackageManager;
+import android.graphics.Rect;
+import android.os.Build;
+import android.util.Log;
+import android.util.Rational;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+final public class PictureInPictureUtils {
+    static Rect calculateRectHint(View view) {
+        Rect hint = new Rect();
+        view.getGlobalVisibleRect(hint);
+        int[] location = new int[2];
+
+        view.getLocationOnScreen(location);
+
+        // getGlobalVisibleRect doesn't take into account the offset for the notch, we use the screen location
+        // of the view to calculate the rectHint.
+        // We only apply this correction on the y axis due to something that looks like a bug in the Android SDK.
+        // If the video screen and home screen have the same orientation this works correctly,
+        // but if the home screen doesn't support landscape and the video screen does, we have to
+        // ignore the offset for the notch on the x axis even though it's present on the video screen
+        // because there will be no offset on the home screen
+        // there is no way to check the orientation support of the home screen, so we make the bet that
+        // it won't support landscape (as most android home screens do by default)
+        // This doesn't have any serious consequences if we are wrong with the guess, the transition will be a bit off
+        // though
+        int height = hint.bottom - hint.top;
+        hint.top = location[1];
+        hint.bottom = hint.top + height;
+        return hint;
+    }
+
+    static void applySourceRectHint(@Nullable Activity activity, View view) {
+        if (Build.VERSION.SDK_INT >= 31 && isPictureInPictureSupported(activity)) {
+            Rect hint = calculateRectHint(view);
+            runWithPiPMisconfigurationSoftHandling(() -> {
+                activity.setPictureInPictureParams(
+                        new PictureInPictureParams.Builder().setSourceRectHint(hint).build());
+            });
+        }
+    }
+
+    static void applyAutoEnter(@Nullable Activity activity, Boolean autoEnterPiP) {
+        if (Build.VERSION.SDK_INT >= 31 && isPictureInPictureSupported(activity)) {
+            runWithPiPMisconfigurationSoftHandling(() -> {
+                activity.setPictureInPictureParams(
+                        new PictureInPictureParams.Builder().setAutoEnterEnabled(autoEnterPiP).build());
+            });
+        }
+    }
+
+    public static boolean isPictureInPictureSupported(Activity currentActivity) {
+        if (currentActivity == null) return false;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && currentActivity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
+    }
+
+    static void applyAspectRatio(Activity currentActivity, Rational rational) {
+        Rational finalAspectRatio = getFinalAspectRatio(rational);
+        runWithPiPMisconfigurationSoftHandling(() -> {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isPictureInPictureSupported(currentActivity)) {
+                currentActivity.setPictureInPictureParams(
+                        new PictureInPictureParams.Builder().setAspectRatio(finalAspectRatio).build());
+            }
+        });
+    }
+
+    static void safeEnterPictureInPicture(@Nullable Activity currentActivity) {
+        runWithPiPMisconfigurationSoftHandling(() -> {
+            if (!isPictureInPictureSupported(currentActivity)) return;
+            currentActivity.enterPictureInPictureMode();
+        });
+    }
+
+    private static @NonNull Rational getFinalAspectRatio(Rational rational) {
+        Rational aspectRatio = rational;
+
+        if (aspectRatio.isNaN()) {
+            aspectRatio = new Rational(150, 200);
+        }
+        Rational maximumRatio = new Rational(239, 100);
+        Rational minimumRatio = new Rational(100, 239);
+
+        if (aspectRatio.floatValue() > maximumRatio.floatValue()) {
+            aspectRatio = maximumRatio;
+        } else if (aspectRatio.floatValue() < minimumRatio.floatValue()) {
+            aspectRatio = minimumRatio;
+        }
+
+        return aspectRatio;
+    }
+
+    public static void runWithPiPMisconfigurationSoftHandling(@NonNull Runnable block) {
+        try {
+            block.run();
+        } catch (IllegalStateException e) {
+            Log.e("com.oney.WebRTCModule", "Current activity does not support picture-in-picture.");
+        }
+    }
+}

--- a/examples/GumTestApp/App.js
+++ b/examples/GumTestApp/App.js
@@ -14,29 +14,33 @@ import {
   View,
   StatusBar,
 } from 'react-native';
-import { Colors } from 'react-native/Libraries/NewAppScreen';
-import { mediaDevices, startIOSPIP, stopIOSPIP, RTCPIPView } from 'react-native-webrtc';
-
+import {Colors} from 'react-native/Libraries/NewAppScreen';
+import {
+  mediaDevices,
+  RTCView,
+  startPIP,
+  stopPIP,
+} from 'react-native-webrtc';
 
 const App = () => {
-  const view = useRef()
+  const view = useRef();
   const [stream, setStream] = useState(null);
   const start = async () => {
     console.log('start');
     if (!stream) {
       try {
-        const s = await mediaDevices.getUserMedia({ video: true });
+        const s = await mediaDevices.getUserMedia({video: true});
         setStream(s);
-      } catch(e) {
+      } catch (e) {
         console.error(e);
       }
     }
   };
-  const startPIP = () => {
-    startIOSPIP(view);
+  const handleStartPIP = () => {
+    startPIP(view);
   };
-  const stopPIP = () => {
-    stopIOSPIP(view);
+  const handleStopPIP = () => {
+    stopPIP(view);
   };
   const stop = () => {
     console.log('stop');
@@ -45,41 +49,33 @@ const App = () => {
       setStream(null);
     }
   };
-  let pipOptions = {
-    startAutomatically: true,
-    fallbackView: (<View style={{ height: 50, width: 50, backgroundColor: 'red' }} />),
-    preferredSize: {
-      width: 400,
-      height: 800,
-    }
-  }
+  
   return (
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView style={styles.body}>
-      {
-        stream &&
-        <RTCPIPView
+        {stream && (
+          <RTCView
             ref={view}
             streamURL={stream.toURL()}
             style={styles.stream}
-            iosPIP={pipOptions} >
-        </RTCPIPView>
-      }
-        <View
-          style={styles.footer}>
-          <Button
-            title = "Start"
-            onPress = {start} />
-          <Button
-            title = "Start PIP"
-            onPress = {startPIP} />
-          <Button
-            title = "Stop PIP"
-            onPress = {stopPIP} />
-          <Button
-            title = "Stop"
-            onPress = {stop} />
+            pictureInPictureOptions={{
+              startAutomatically: true,
+              preferredSize: {
+                width: 400,
+                height: 800,
+              }
+            }}
+            onPictureInPictureChange={({nativeEvent}) =>console.log(nativeEvent)}
+          >
+              <View style={{height: 50, width: 50, backgroundColor: 'red'}} />
+          </RTCView>
+        )}
+        <View style={styles.footer}>
+          <Button title="Start" onPress={start} />
+          <Button title="Start PIP" onPress={handleStartPIP} />
+          <Button title="Stop PIP" onPress={handleStopPIP} />
+          <Button title="Stop" onPress={stop} />
         </View>
       </SafeAreaView>
     </>
@@ -89,17 +85,17 @@ const App = () => {
 const styles = StyleSheet.create({
   body: {
     backgroundColor: Colors.white,
-    ...StyleSheet.absoluteFill
+    ...StyleSheet.absoluteFill,
   },
   stream: {
-    flex: 1
+    flex: 1,
   },
   footer: {
     backgroundColor: Colors.lighter,
     position: 'absolute',
     bottom: 0,
     left: 0,
-    right: 0
+    right: 0,
   },
 });
 

--- a/examples/GumTestApp/android/app/src/main/AndroidManifest.xml
+++ b/examples/GumTestApp/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:supportsPictureInPicture="true"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode|smallestScreenSize|screenLayout"
         android:exported="true"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize">

--- a/ios/RCTWebRTC/PIPController.h
+++ b/ios/RCTWebRTC/PIPController.h
@@ -4,6 +4,10 @@
 
 #import "RTCVideoViewManager.h"
 
+@protocol PIPControllerDelegate<NSObject>
+- (void)didChangePictureInPicture:(BOOL)isInPictureInPicture;
+@end
+
 API_AVAILABLE(ios(15.0))
 @interface PIPController : NSObject<AVPictureInPictureControllerDelegate>
 
@@ -13,6 +17,7 @@ API_AVAILABLE(ios(15.0))
 @property(nonatomic, assign) BOOL startAutomatically;
 @property(nonatomic, assign) BOOL stopAutomatically;
 @property(nonatomic, assign) CGSize preferredSize;
+@property(nonatomic, weak) id<PIPControllerDelegate> delegate;
 
 - (instancetype)initWithSourceView:(UIView *)sourceView;
 - (void)togglePIP;

--- a/ios/RCTWebRTC/PIPController.m
+++ b/ios/RCTWebRTC/PIPController.m
@@ -155,6 +155,12 @@
     }
 }
 
+- (void)didChangePictureInPicture:(BOOL)isInPictureInPicture {
+    if ([self.delegate respondsToSelector:@selector(didChangePictureInPicture:)]) {
+        [self.delegate didChangePictureInPicture:isInPictureInPicture];
+    }
+}
+
 - (void)dealloc {
     [_videoTrack removeRenderer:_sampleView];
     [_pipController removeObserver:self forKeyPath:@"pictureInPictureActive"];
@@ -182,6 +188,7 @@
     @abstract    Delegate can implement this method to be notified when Picture in Picture did start.
  */
 - (void)pictureInPictureControllerDidStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
+    [self didChangePictureInPicture:YES];
     NSLog(@"%@", NSStringFromSelector(_cmd));  // Objective-C
 }
 
@@ -215,6 +222,7 @@
     @abstract    Delegate can implement this method to be notified when Picture in Picture did stop.
  */
 - (void)pictureInPictureControllerDidStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
+    [self didChangePictureInPicture:NO];
     NSLog(@"%@", NSStringFromSelector(_cmd));  // Objective-C
 }
 

--- a/src/RTCPIPView.tsx
+++ b/src/RTCPIPView.tsx
@@ -13,6 +13,7 @@ type RTCViewInstance = InstanceType<typeof RTCView>;
 
 /**
  * A convenience wrapper around RTCView to handle the fallback view as a prop.
+ * @deprecated use RTCView instead
  */
 const RTCPIPView = forwardRef<RTCViewInstance, RTCPIPViewProps>((props, ref) => {
     const rtcViewProps = { ...props };
@@ -28,6 +29,10 @@ const RTCPIPView = forwardRef<RTCViewInstance, RTCPIPViewProps>((props, ref) => 
     );
 });
 
+/**
+ *
+ * @deprecated use startPIP
+ */
 export function startIOSPIP(ref) {
     UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(ref.current),
@@ -36,6 +41,10 @@ export function startIOSPIP(ref) {
     );
 }
 
+/**
+ *
+ * @deprecated use stopPIP
+ */
 export function stopIOSPIP(ref) {
     UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(ref.current),

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,13 @@ import RTCRtpReceiver from './RTCRtpReceiver';
 import RTCRtpSender from './RTCRtpSender';
 import RTCRtpTransceiver from './RTCRtpTransceiver';
 import RTCSessionDescription from './RTCSessionDescription';
-import RTCView, { type RTCVideoViewProps, type RTCIOSPIPOptions } from './RTCView';
+import RTCView, {
+    type RTCVideoViewProps,
+    type RTCIOSPIPOptions,
+    type RTCPictureInPictureOptions,
+    startPIP,
+    stopPIP
+} from './RTCView';
 import ScreenCapturePickerView from './ScreenCapturePickerView';
 
 Logger.enable(`${Logger.ROOT_PREFIX}:*`);
@@ -54,6 +60,9 @@ export {
     registerGlobals,
     startIOSPIP,
     stopIOSPIP,
+    type RTCPictureInPictureOptions,
+    startPIP,
+    stopPIP
 };
 
 declare const global: any;


### PR DESCRIPTION
A simplified version of #1710 

- Add support Android PIP support.
- Add onPictureInPicture in both Android and iOS.
- Deprecates RTCPIPView for RTCView (Now support children in both Android and iOS).
- Update examples