### PR TITLE
android: fix NPE in gUM

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -196,8 +196,14 @@ class GetUserMediaImpl {
 
             Log.d(TAG, "getUserMedia(video): " + videoConstraintsMap);
 
+            Activity currentActivity = this.reactContext.getCurrentActivity();
+            if (currentActivity == null) {
+                errorCallback.invoke("Error", "No current Activity.");
+                return;
+            }
+
             CameraCaptureController cameraCaptureController = new CameraCaptureController(
-                    reactContext.getCurrentActivity(), getCameraEnumerator(), videoConstraintsMap);
+                    currentActivity, getCameraEnumerator(), videoConstraintsMap);
 
             videoTrack = createVideoTrack(cameraCaptureController);
         }


### PR DESCRIPTION
As unlikely as it seems, we are observing this on Crashlytics:

```
          Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object android.content.Context.getSystemService(java.lang.String)' on a null object reference
       at com.oney.WebRTCModule.CameraCaptureController.createVideoCapturer(CameraCaptureController.java:103)
       at com.oney.WebRTCModule.AbstractVideoCaptureController.initializeVideoCapturer(AbstractVideoCaptureController.java)
       at com.oney.WebRTCModule.GetUserMediaImpl.createVideoTrack(GetUserMediaImpl.java)
       at com.oney.WebRTCModule.GetUserMediaImpl.getUserMedia(GetUserMediaImpl.java:197)
       at com.oney.WebRTCModule.WebRTCModule.lambda$getUserMedia$11(WebRTCModule.java:777)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```
