### PR TITLE
add mediaConstraints on getDisplayMedia 

### DIFF
--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -115,12 +115,16 @@ try {
 ### Using Media Constraints on getDisplayMedia (Android Only)
 
 It is possible to use mediaConstraints on getDisplayMedia to restricts the user to capturing the default display using the custom boolean parameter `createConfigForDefaultDisplay`.
-A resolution scale can also be applied using `resolutionScale` parameter. Value is a number between 0 and 1 
+A resolution scale can also be applied using `resolutionScale` parameter. Value is a number between 0 and 1.
+
+This configuration in only available for android, so will you have to add the 'android' key in constraints.
 
 ```javascript
 	const displayMediaStreamConstraints = {
-		createConfigForDefaultDisplay: true,
-		resolutionScale: 0.5,
+		android: {
+			createConfigForDefaultDisplay: true,
+			resolutionScale: 0.5,
+		},
 	};
 ```
 

--- a/Documentation/BasicUsage.md
+++ b/Documentation/BasicUsage.md
@@ -112,6 +112,18 @@ try {
 };
 ```
 
+### Using Media Constraints on getDisplayMedia (Android Only)
+
+It is possible to use mediaConstraints on getDisplayMedia to restricts the user to capturing the default display using the custom boolean parameter `createConfigForDefaultDisplay`.
+A resolution scale can also be applied using `resolutionScale` parameter. Value is a number between 0 and 1 
+
+```javascript
+	const displayMediaStreamConstraints = {
+		createConfigForDefaultDisplay: true,
+		resolutionScale: 0.5,
+	};
+```
+
 ## Destroying the Media Stream
 
 Cycling all of the tracks and stopping them is more than enough to clean up after a call has finished.  

--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -273,21 +273,33 @@ class GetUserMediaImpl {
 
         // Handle the incoming params
 
-        // MediaProjectionConfig need API level 34
-        this.createConfigForDefaultDisplay =
-            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-            && constraints.hasKey("createConfigForDefaultDisplay")
-            && (constraints.getType("createConfigForDefaultDisplay") == ReadableType.Boolean)
-            && constraints.getBoolean("createConfigForDefaultDisplay");
-
-        float scale = 1.0f;
-        if (constraints.hasKey("resolutionScale") && (constraints.getType("resolutionScale") == ReadableType.Number)) {
-            scale = (float) constraints.getDouble("resolutionScale");
+        ReadableMap androidConstraints = null;
+        if (constraints.hasKey("android") && constraints.getType("android") == ReadableType.Map) {
+            androidConstraints = constraints.getMap("android");
         }
-        // Force la valeur dans [0, 1]
+
+        // Default values
+        boolean createConfigForDefaultDisplay = false;
+        float scale = 1.0f;
+
+        if (androidConstraints != null) {
+            // MediaProjectionConfig need API level 34
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+                && androidConstraints.hasKey("createConfigForDefaultDisplay")
+                && androidConstraints.getType("createConfigForDefaultDisplay") == ReadableType.Boolean) {
+                createConfigForDefaultDisplay = androidConstraints.getBoolean("createConfigForDefaultDisplay");
+            }
+            if (androidConstraints.hasKey("resolutionScale")
+                && androidConstraints.getType("resolutionScale") == ReadableType.Number) {
+                scale = (float) androidConstraints.getDouble("resolutionScale");
+            }
+        }
+
+        this.createConfigForDefaultDisplay = createConfigForDefaultDisplay;
+        // Force the value in [0, 1]
         this.resolutionScale = Math.max(0.0f, Math.min(1.0f, scale));
 
-        Log.d(TAG, "######### initializeConstraints: createConfigForDefaultDisplay=" + this.createConfigForDefaultDisplay
+        Log.d(TAG, "initializeConstraints: createConfigForDefaultDisplay=" + this.createConfigForDefaultDisplay
             + " resolutionScale=" + this.resolutionScale);
     }
 

--- a/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
@@ -25,8 +25,8 @@ public class ScreenCaptureController extends AbstractVideoCaptureController {
 
     private final Context context;
 
-    public ScreenCaptureController(Context context, int width, int height, Intent mediaProjectionPermissionResultData) {
-        super(width, height, DEFAULT_FPS);
+    public ScreenCaptureController(Context context, int width, int height, Intent mediaProjectionPermissionResultData, float resolutionScale) {
+        super((int)(width * resolutionScale), (int)(height * resolutionScale), DEFAULT_FPS);
 
         this.mediaProjectionPermissionResultData = mediaProjectionPermissionResultData;
 
@@ -36,8 +36,8 @@ public class ScreenCaptureController extends AbstractVideoCaptureController {
             @Override
             public void onOrientationChanged(int orientation) {
                 DisplayMetrics displayMetrics = DisplayUtils.getDisplayMetrics((Activity) context);
-                final int width = displayMetrics.widthPixels;
-                final int height = displayMetrics.heightPixels;
+                final int width = (int)(displayMetrics.widthPixels * resolutionScale);
+                final int height = (int)(displayMetrics.heightPixels * resolutionScale);
 
                 // Pivot to the executor thread because videoCapturer.changeCaptureFormat runs in the main
                 // thread and may deadlock.

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -759,8 +759,8 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getDisplayMedia(Promise promise) {
-        ThreadUtils.runOnExecutor(() -> getUserMediaImpl.getDisplayMedia(promise));
+    public void getDisplayMedia(ReadableMap constraints, Promise promise) {
+        ThreadUtils.runOnExecutor(() -> getUserMediaImpl.getDisplayMedia(constraints, promise));
     }
 
     @ReactMethod

--- a/examples/GumTestApp/android/build.gradle
+++ b/examples/GumTestApp/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "33.0.2"
         minSdkVersion = 24
-        compileSdkVersion = 33
+        compileSdkVersion = 34
         targetSdkVersion = 33
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -161,7 +161,7 @@
     return videoTrack;
 }
 
-RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(getDisplayMedia : (NSDictionary *)constraints resolver : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject) {
 #if TARGET_OS_TV
     reject(@"unsupported_platform", @"tvOS is not supported", nil);
     return;

--- a/src/MediaDevices.ts
+++ b/src/MediaDevices.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 
-import getDisplayMedia from './getDisplayMedia';
-import getUserMedia, { Constraints } from './getUserMedia';
+import getDisplayMedia, { Constraints as DisplayMediaConstraints } from './getDisplayMedia';
+import getUserMedia, { Constraints as UserMediaConstraints } from './getUserMedia';
 import { Event, EventTarget, getEventAttributeValue, setEventAttributeValue } from './vendor/event-target-shim';
 
 const { WebRTCModule } = NativeModules;
@@ -34,7 +34,7 @@ class MediaDevices extends EventTarget<MediaDevicesEventMap> {
      * @param {*} constraints
      * @returns {Promise}
      */
-    getDisplayMedia(constraints: Constraints) {
+    getDisplayMedia(constraints: DisplayMediaConstraints) {
         return getDisplayMedia(constraints);
     }
 
@@ -46,7 +46,7 @@ class MediaDevices extends EventTarget<MediaDevicesEventMap> {
      * @param {*} constraints
      * @returns {Promise}
      */
-    getUserMedia(constraints: Constraints) {
+    getUserMedia(constraints: UserMediaConstraints) {
         return getUserMedia(constraints);
     }
 }

--- a/src/MediaDevices.ts
+++ b/src/MediaDevices.ts
@@ -31,10 +31,11 @@ class MediaDevices extends EventTarget<MediaDevicesEventMap> {
      * W3C "Screen Capture" compatible {@code getDisplayMedia} implementation.
      * See: https://w3c.github.io/mediacapture-screen-share/
      *
+     * @param {*} constraints
      * @returns {Promise}
      */
-    getDisplayMedia() {
-        return getDisplayMedia();
+    getDisplayMedia(constraints: Constraints) {
+        return getDisplayMedia(constraints);
     }
 
     /**

--- a/src/getDisplayMedia.ts
+++ b/src/getDisplayMedia.ts
@@ -7,8 +7,10 @@ import MediaStreamError from './MediaStreamError';
 const { WebRTCModule } = NativeModules;
 
 export interface Constraints {
-    createConfigForDefaultDisplay?: boolean;
-    resolutionScale?: number;
+    android?: {
+        createConfigForDefaultDisplay?: boolean;
+        resolutionScale?: number;
+    }
 }
 
 export default function getDisplayMedia(constraints: Constraints = {}): Promise<MediaStream> {

--- a/src/getDisplayMedia.ts
+++ b/src/getDisplayMedia.ts
@@ -6,9 +6,14 @@ import MediaStreamError from './MediaStreamError';
 
 const { WebRTCModule } = NativeModules;
 
-export default function getDisplayMedia(): Promise<MediaStream> {
+export interface Constraints {
+    createConfigForDefaultDisplay?: boolean;
+    resolutionScale?: number;
+}
+
+export default function getDisplayMedia(constraints: Constraints = {}): Promise<MediaStream> {
     return new Promise((resolve, reject) => {
-        WebRTCModule.getDisplayMedia().then(
+        WebRTCModule.getDisplayMedia(constraints).then(
             data => {
                 const { streamId, track } = data;
 


### PR DESCRIPTION

Main goal of this PR it to add the possibility to limit the user choice for displayMedia on Android 14+

It is possible to use mediaConstraints on getDisplayMedia to restricts the user to capturing the default display using the custom boolean parameter `createConfigForDefaultDisplay`.

createConfigForDefaultDisplay use the MediaProjectionConfig as described here : https://developer.android.com/reference/kotlin/android/media/projection/MediaProjectionConfig

User will be limited to share his mobile "full screen".


A resolution scale can also be applied using `resolutionScale` parameter. Value is a number between 0 and 1 


```javascript
	const displayMediaStreamConstraints = {
		createConfigForDefaultDisplay: true,
		resolutionScale: 0.5,
	};
```


=> Tested on Android 11, Android 15 and iOS (no impact)
