### PR TITLE
ios: Implement ScreenCapturePickerViewManager.showAwaiting

### DIFF
--- a/ios/RCTWebRTC/ScreenCapturePickerViewManager.m
+++ b/ios/RCTWebRTC/ScreenCapturePickerViewManager.m
@@ -7,6 +7,39 @@
 
 NSString *const kRTCScreenSharingExtension = @"RTCScreenSharingExtension";
 
+/**
+ * Clears observers registered by showAwaiting
+ */
+void clearObservers(NSMutableDictionary *promiseDict) {
+    
+    if (!promiseDict) {
+        return;
+    }
+    
+    CFNotificationCenterRef darwinCenter = CFNotificationCenterGetDarwinNotifyCenter();
+    CFNotificationCenterRemoveObserver(darwinCenter, (__bridge void*)promiseDict, CFSTR("iOS_BroadcastStarted"), NULL);
+    
+    id nsObserver = promiseDict[@"ns_observer"];
+    if(nsObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:nsObserver];
+    };
+    [promiseDict removeAllObjects];
+}
+
+/**
+ * Callback function for iOS_BroadcastStarted notification
+ */
+void onBroadcastStarted(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
+    NSMutableDictionary *promiseDict = (__bridge_transfer NSMutableDictionary*)observer;
+    RCTPromiseResolveBlock resolve = promiseDict[@"resolve"];
+    if (resolve) {
+        resolve(nil);
+    }
+    
+    clearObservers(promiseDict);
+    
+}
+
 @implementation ScreenCapturePickerViewManager {
     RPSystemBroadcastPickerView *_broadcastPickerView;
 }
@@ -46,6 +79,76 @@ RCT_EXPORT_METHOD(show : (nonnull NSNumber *)reactTag) {
                         btn = (UIButton *)subview;
                     }
                 }
+                if (btn != nil) {
+                    [btn sendActionsForControlEvents:UIControlEventTouchUpInside];
+                } else {
+                    RCTLogError(@"RPSystemBroadcastPickerView button not found");
+                }
+            }
+        }];
+}
+
+/**
+ * Shows the RPSystemBroadcastPickerView and waits for either the broadcast to
+ * start, or a 5 second timeout after the picker has been dismissed (broadcast
+ * only starts after a 3 second countdown.)
+ */
+RCT_EXPORT_METHOD(showAwaiting: (nonnull NSNumber *)reactTag
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject) {
+    [self.bridge.uiManager
+        addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+            id view = viewRegistry[reactTag];
+            if (![view isKindOfClass:[RPSystemBroadcastPickerView class]]) {
+                RCTLogError(@"Invalid view returned from registry, expecting "
+                            @"RPSystemBroadcastPickerView, got: %@",
+                            view);
+            } else {
+                // Simulate a click
+                UIButton *btn = nil;
+
+                for (UIView *subview in ((RPSystemBroadcastPickerView *)view).subviews) {
+                    if ([subview isKindOfClass:[UIButton class]]) {
+                        btn = (UIButton *)subview;
+                    }
+                }
+                
+                NSMutableDictionary *promiseDict = [NSMutableDictionary dictionaryWithDictionary:@{
+                    @"resolve": resolve,
+                    @"reject": reject
+                }];
+                
+                __weak NSMutableDictionary *weakDict = promiseDict;
+                __weak id nsObserver = nil;
+
+                // Observer for picker dismissal
+                nsObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+                    if(weakDict != NULL && [weakDict count] != 0) {
+                        // Timeout after 5 seconds, if blockDict still has valid keys.
+                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                            NSMutableDictionary * blockDict = weakDict;
+                            
+                            if(blockDict != NULL && [blockDict count] != 0) {
+                                RCTPromiseRejectBlock rejecter = blockDict[@"reject"];
+                                if(rejecter) {
+                                    rejecter(@"ScreenCaptureViewManager.showAwaiting", @"Did not result in broadcast starting!", nil);
+                                }
+                                clearObservers(blockDict);
+                            }
+                        });
+                    }
+                }];
+                promiseDict[@"ns_observer"] = nsObserver;
+                
+                // Observer for broadcast starting
+                CFNotificationCenterRef notification = CFNotificationCenterGetDarwinNotifyCenter();
+                CFNotificationCenterAddObserver(notification,
+                                                (__bridge_retained const void *)promiseDict,
+                                                onBroadcastStarted,
+                                                CFSTR("iOS_BroadcastStarted"),
+                                                NULL,
+                                                CFNotificationSuspensionBehaviorDeliverImmediately);
+                                
                 if (btn != nil) {
                     [btn sendActionsForControlEvents:UIControlEventTouchUpInside];
                 } else {


### PR DESCRIPTION
This adds a separate `showAwaiting` method to the ScreenCapturePickerViewManager, which blocks the async call until the broadcast has started, or rejects after a timeout of 5 seconds after dismissal (the broadcast only starts after a 3 second countdown).

Uses this to detect the dismissal: https://stackoverflow.com/a/76621153/295675

The old `show` method only shows the picker, and there's no way of knowing if the broadcast has started (and subsequently be left hanging on whether a subsequent `getDisplayMedia` call will succeed in getting the screen capture or not). This new API allows the SDK consumer to be more informed on whether the user has elected to start the broadcast.