### PR TITLE
feat(ios): add blurIntensity support for PiP video call view

### DIFF
--- a/ios/RCTWebRTC/PIPController.h
+++ b/ios/RCTWebRTC/PIPController.h
@@ -13,6 +13,7 @@ API_AVAILABLE(ios(15.0))
 @property(nonatomic, assign) BOOL startAutomatically;
 @property(nonatomic, assign) BOOL stopAutomatically;
 @property(nonatomic, assign) CGSize preferredSize;
+@property(nonatomic, assign) CGFloat blurIntensity;
 
 - (instancetype)initWithSourceView:(UIView *)sourceView;
 - (void)togglePIP;

--- a/ios/RCTWebRTC/PIPController.m
+++ b/ios/RCTWebRTC/PIPController.m
@@ -127,6 +127,11 @@
     }
 }
 
+- (void)setBlurIntensity:(CGFloat)blurIntensity {
+    _blurIntensity = blurIntensity;
+    _sampleView.blurIntensity = blurIntensity;
+}
+
 - (BOOL)startAutomatically {
     return _pipController.canStartPictureInPictureAutomaticallyFromInline;
 }

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -197,10 +197,16 @@
         _pipController.videoTrack = _videoTrack;
     }
 
+    CGFloat blurIntensity = 0;
+    if ([pipOptions objectForKey:@"blurIntensity"]) {
+        blurIntensity = [pipOptions[@"blurIntensity"] doubleValue];
+    }
+
     _pipController.startAutomatically = startAutomatically;
     _pipController.stopAutomatically = stopAutomatically;
     _pipController.objectFit = _objectFit;
     _pipController.preferredSize = preferredSize;
+    _pipController.blurIntensity = blurIntensity;
 }
 
 - (void)API_AVAILABLE(ios(15.0))startPIP {

--- a/ios/RCTWebRTC/SampleBufferVideoCallView.h
+++ b/ios/RCTWebRTC/SampleBufferVideoCallView.h
@@ -7,6 +7,7 @@
 
 @property(nonnull, nonatomic, readonly) AVSampleBufferDisplayLayer *sampleBufferLayer;
 @property(nonatomic, assign) BOOL shouldRender;
+@property(nonatomic, assign) CGFloat blurIntensity;
 
 - (void)requestScaleRecalculation;
 @end

--- a/ios/RCTWebRTC/SampleBufferVideoCallView.m
+++ b/ios/RCTWebRTC/SampleBufferVideoCallView.m
@@ -20,6 +20,7 @@
 @property(nonatomic, retain) I420Converter *i420Converter;
 @property(nonatomic, strong) id<SampleBufferRendering> renderer;
 @property(nonatomic, assign) NSInteger currentRotation;
+@property(nonatomic, strong) UIVisualEffectView *blurEffectView;
 
 @end
 
@@ -169,6 +170,32 @@
     CVPixelBufferRef convertedPixelBuffer = [_i420Converter convertI420ToPixelBuffer:i420Buffer];
 
     return convertedPixelBuffer;
+}
+
+- (void)setBlurIntensity:(CGFloat)blurIntensity {
+    blurIntensity = MAX(0.0, MIN(1.0, blurIntensity));
+    if (_blurIntensity == blurIntensity) {
+        return;
+    }
+    _blurIntensity = blurIntensity;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (blurIntensity > 0) {
+            if (!self.blurEffectView) {
+                UIBlurEffect *effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
+                self.blurEffectView = [[UIVisualEffectView alloc] initWithEffect:effect];
+                self.blurEffectView.autoresizingMask =
+                    UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            }
+            self.blurEffectView.frame = self.bounds;
+            self.blurEffectView.alpha = blurIntensity;
+            if (!self.blurEffectView.superview) {
+                [self addSubview:self.blurEffectView];
+            }
+        } else {
+            [self.blurEffectView removeFromSuperview];
+        }
+    });
 }
 
 - (void)dealloc {


### PR DESCRIPTION
## Summary

- Adds a `blurIntensity` option (0.0–1.0) to the `iosPIP` prop that overlays a `UIVisualEffectView` on the `SampleBufferVideoCallView`
- Allows apps to blur the PiP camera feed for privacy (e.g. during screen sharing) without disabling the camera entirely
- Defaults to 0 (no blur) — no breaking change for existing users

## Usage

```jsx
<RTCView
  iosPIP={{
    startAutomatically: true,
    stopAutomatically: true,
    preferredSize: { width: 9, height: 16 },
    blurIntensity: 0.8,
  }}
/>
```

## Motivation

When an app needs to blur the local camera for privacy (e.g. hiding sensitive content during screen share), blur overlays rendered in React Native are invisible to the native `AVPictureInPictureController` — PiP only captures the `SampleBufferVideoCallView`'s video layer. This means the PiP window shows the raw unblurred camera feed even when the in-app view is blurred.

The only workaround without this change is to disable the camera entirely when blur is needed, which kills the PiP window.

## Changes

| File | Change |
|------|--------|
| `SampleBufferVideoCallView.h` | Added `blurIntensity` property (`CGFloat`) |
| `SampleBufferVideoCallView.m` | `UIVisualEffectView` overlay with alpha controlled by `blurIntensity` |
| `PIPController.h` | Added `blurIntensity` property |
| `PIPController.m` | Forwards `blurIntensity` to `SampleBufferVideoCallView` |
| `RTCVideoViewManager.m` | Reads `blurIntensity` from `iosPIP` dict |

## Test plan

- [ ] Set `iosPIP={{ blurIntensity: 1.0, ... }}` — PiP should show fully blurred feed
- [ ] Set `blurIntensity: 0.5` — PiP should show partially blurred feed
- [ ] Set `blurIntensity: 0` or omit — PiP should show clear camera feed (default)
- [ ] Toggle blur while PiP is active — overlay should appear/disappear