### PR TITLE
[ios] Use runtime camera checks on simulator for camera availability

### DIFF
--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -125,15 +125,22 @@
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
     RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
 
-#if !TARGET_IPHONE_SIMULATOR
-    RTCCameraVideoCapturer *videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
-    VideoCaptureController *videoCaptureController =
-        [[VideoCaptureController alloc] initWithCapturer:videoCapturer andConstraints:constraints[@"video"]];
-    videoCaptureController.enableMultitaskingCameraAccess =
-        [WebRTCModuleOptions sharedInstance].enableMultitaskingCameraAccess;
-    videoTrack.captureController = videoCaptureController;
-    [videoCaptureController startCapture];
+    BOOL hasRuntimeVideoDevice = YES;
+#if TARGET_IPHONE_SIMULATOR
+    // On simulator, a runtime-provided video source may exist (e.g. virtual camera),
+    // so only skip camera capture setup when no runtime video device is available.
+    hasRuntimeVideoDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo] != nil;
 #endif
+
+    if (hasRuntimeVideoDevice) {
+        RTCCameraVideoCapturer *videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
+        VideoCaptureController *videoCaptureController =
+            [[VideoCaptureController alloc] initWithCapturer:videoCapturer andConstraints:constraints[@"video"]];
+        videoCaptureController.enableMultitaskingCameraAccess =
+            [WebRTCModuleOptions sharedInstance].enableMultitaskingCameraAccess;
+        videoTrack.captureController = videoCaptureController;
+        [videoCaptureController startCapture];
+    }
 
     return videoTrack;
 #endif


### PR DESCRIPTION
# Why

The current iOS implementation uses a compile-time simulator guard that always skips camera capture setup on Simulator. That makes simulator behavior diverge from runtime capability and blocks valid camera flows when a runtime video source is available.

I made similar PRs for [expo-camera](https://github.com/expo/expo/pull/44159) and [vision-camera](https://github.com/mrousavy/react-native-vision-camera/pull/3724) where compile time checks were present too.

# How

This change replaces the unconditional simulator skip in `createVideoTrack(...)` with a simulator-only runtime camera availability check:

- Add a runtime guard on Simulator using `AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo`.
- Keep camera capture setup enabled when a runtime video device is available.
- Preserve fallback behavior when no runtime video device is available.
- Leave non-simulator platforms unchanged.

# Test Plan

- iOS Simulator: verify `getUserMedia({ video: true })` keeps existing no-camera fallback behavior (no capture controller setup).
- Physical iOS device: verify camera track creation behavior remains unchanged.