### PR TITLE
fix(android): resolve D8 nest mates dex error with AGP 8.12+

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
+++ b/android/src/main/java/com/oney/WebRTCModule/VideoTrackAdapter.java
@@ -68,9 +68,9 @@ public class VideoTrackAdapter {
      */
     private class TrackMuteUnmuteImpl implements VideoSink {
         private TimerTask emitMuteTask;
-        private volatile boolean disposed;
-        private AtomicInteger frameCounter;
-        private boolean mutedState;
+        volatile boolean disposed;
+        AtomicInteger frameCounter;
+        boolean mutedState;
         private final String trackId;
 
         TrackMuteUnmuteImpl(String trackId) {
@@ -92,23 +92,7 @@ public class VideoTrackAdapter {
                 if (emitMuteTask != null) {
                     emitMuteTask.cancel();
                 }
-                emitMuteTask = new TimerTask() {
-                    private int lastFrameNumber = frameCounter.get();
-
-                    @Override
-                    public void run() {
-                        if (disposed) {
-                            return;
-                        }
-                        boolean isMuted = lastFrameNumber == frameCounter.get();
-                        if (isMuted != mutedState) {
-                            mutedState = isMuted;
-                            emitMuteEvent(isMuted);
-                        }
-
-                        lastFrameNumber = frameCounter.get();
-                    }
-                };
+                emitMuteTask = new MuteCheckTask(this);
                 timer.schedule(emitMuteTask, INITIAL_MUTE_DELAY, MUTE_DELAY);
             }
         }
@@ -132,6 +116,32 @@ public class VideoTrackAdapter {
                     emitMuteTask = null;
                 }
             }
+        }
+    }
+
+    /**
+     * Named TimerTask to avoid anonymous inner class nest mate issues with AGP 8.12+.
+     */
+    private static class MuteCheckTask extends TimerTask {
+        private final TrackMuteUnmuteImpl impl;
+        private int lastFrameNumber;
+
+        MuteCheckTask(TrackMuteUnmuteImpl impl) {
+            this.impl = impl;
+            this.lastFrameNumber = impl.frameCounter.get();
+        }
+
+        @Override
+        public void run() {
+            if (impl.disposed) {
+                return;
+            }
+            boolean isMuted = lastFrameNumber == impl.frameCounter.get();
+            if (isMuted != impl.mutedState) {
+                impl.mutedState = isMuted;
+                impl.emitMuteEvent(isMuted);
+            }
+            lastFrameNumber = impl.frameCounter.get();
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes Android build failure with AGP 8.12 (Gradle 9), which ships with Expo SDK 55 / React Native 0.82+.

The anonymous `TimerTask` inner class in `VideoTrackAdapter.TrackMuteUnmuteImpl` creates a nest mate class (`VideoTrackAdapter$TrackMuteUnmuteImpl$1`) that D8's `DexingNoClasspathTransform` cannot resolve:

```
D8: Compilation of classes com.oney.WebRTCModule.VideoTrackAdapter,
com.oney.WebRTCModule.VideoTrackAdapter$TrackMuteUnmuteImpl requires
its nest mates com.oney.WebRTCModule.VideoTrackAdapter$TrackMuteUnmuteImpl$1
(unavailable) to be on program or class path
```

## Fix

- Replace the anonymous `TimerTask` with a named static `MuteCheckTask` inner class
- Relax field visibility on `disposed`, `frameCounter`, `mutedState` from `private` to package-private so the static class can access them
- No behavioral changes — same logic, just restructured to avoid the anonymous nest mate

## Tested with

- AGP 8.12.0 / Gradle 9.0.0
- Expo SDK 55 / React Native 0.82
- react-native-webrtc 124.0.7
- Physical Android device (API 34)