### PR TITLE
fix(android): include microphone foreground service type for media projection

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/MediaProjectionService.java
+++ b/android/src/main/java/com/oney/WebRTCModule/MediaProjectionService.java
@@ -72,7 +72,11 @@ public class MediaProjectionService extends Service {
         Notification notification = MediaProjectionNotification.buildMediaProjectionNotification(this);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
+            int serviceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                serviceType |= ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION_MEDIA_PROJECTOR;
+            }
+            startForeground(NOTIFICATION_ID, notification, serviceType);
         } else {
             startForeground(NOTIFICATION_ID, notification);
         }


### PR DESCRIPTION
Previously, the media projection service was started only with:
- `FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION`

This change also includes:
- `FOREGROUND_SERVICE_TYPE_MICROPHONE` (Android 11+)

This fixes cases where microphone capture stops or becomes restricted when the app goes into the background during an active screen share.