### PR TITLE
feat: add nativeReceivedEpochMs / nativeReceivedMonotonicMs to data channel onmessage

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/DataChannelWrapper.java
+++ b/android/src/main/java/com/oney/WebRTCModule/DataChannelWrapper.java
@@ -1,5 +1,6 @@
 package com.oney.WebRTCModule;
 
+import android.os.SystemClock;
 import android.util.Base64;
 
 import androidx.annotation.Nullable;
@@ -59,6 +60,8 @@ class DataChannelWrapper implements DataChannel.Observer {
 
     @Override
     public void onMessage(DataChannel.Buffer buffer) {
+        long epochMs = System.currentTimeMillis();
+        double monotonicMs = SystemClock.elapsedRealtimeNanos() / 1_000_000.0;
         WritableMap params = Arguments.createMap();
         params.putString("reactTag", reactTag);
         params.putInt("peerConnectionId", peerConnectionId);
@@ -82,6 +85,8 @@ class DataChannelWrapper implements DataChannel.Observer {
         }
         params.putString("type", type);
         params.putString("data", data);
+        params.putDouble("nativeReceivedEpochMs", (double) epochMs);
+        params.putDouble("nativeReceivedMonotonicMs", monotonicMs);
 
         webRTCModule.sendEvent("dataChannelReceiveMessage", params);
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
@@ -7,6 +7,7 @@
 #import <WebRTC/RTCDataChannelConfiguration.h>
 #import "WebRTCModule+RTCDataChannel.h"
 #import "WebRTCModule+RTCPeerConnection.h"
+#import <QuartzCore/QuartzCore.h>
 
 @implementation WebRTCModule (RTCDataChannel)
 
@@ -117,6 +118,8 @@ RCT_EXPORT_METHOD(dataChannelSend : (nonnull NSNumber *)peerConnectionId reactTa
 
 // Called when a data buffer was successfully received.
 - (void)dataChannel:(DataChannelWrapper *)dcw didReceiveMessageWithBuffer:(RTCDataBuffer *)buffer {
+    NSTimeInterval epochMs = [[NSDate date] timeIntervalSince1970] * 1000.0;
+    double monotonicMs = CACurrentMediaTime() * 1000.0;
     NSString *type;
     NSString *data;
     if (buffer.isBinary) {
@@ -139,7 +142,9 @@ RCT_EXPORT_METHOD(dataChannelSend : (nonnull NSNumber *)peerConnectionId reactTa
         // attempting to insert nil. Such behavior is
         // unacceptable given that protection in such a
         // scenario is extremely simple.
-        @"data" : (data ? data : [NSNull null])
+        @"data" : (data ? data : [NSNull null]),
+        @"nativeReceivedEpochMs" : @(epochMs),
+        @"nativeReceivedMonotonicMs" : @(monotonicMs)
     };
     [self sendEventWithName:kEventDataChannelReceiveMessage body:event];
 }

--- a/src/RTCDataChannel.ts
+++ b/src/RTCDataChannel.ts
@@ -207,7 +207,14 @@ export default class RTCDataChannel extends EventTarget<DataChannelEventMap> {
                 data = base64.toByteArray(ev.data).buffer;
             }
 
-            this.dispatchEvent(new MessageEvent('message', { data }));
+            const messageEvent = new MessageEvent('message', { data });
+            if (typeof ev.nativeReceivedEpochMs === 'number') {
+                (messageEvent as any).nativeReceivedEpochMs = ev.nativeReceivedEpochMs;
+            }
+            if (typeof ev.nativeReceivedMonotonicMs === 'number') {
+                (messageEvent as any).nativeReceivedMonotonicMs = ev.nativeReceivedMonotonicMs;
+            }
+            this.dispatchEvent(messageEvent);
         });
 
         addListener(this, 'dataChannelDidChangeBufferedAmount', (ev: any) => {


### PR DESCRIPTION
## Add native receive timestamps to data channel `onmessage` events

### Problem

When measuring one-way latency through a WebRTC data channel, the natural approach is to
compare the sender's broadcast timestamp (embedded in the payload) against the time the
message was received on the other end. The only available hook for that is the JS-side
`onmessage` callback — but that callback fires on the JS thread, which can be scheduled
**hundreds of milliseconds after the OS actually delivered the packet** under UI or bridge
load. Critically, this error is correlated with high-load conditions: the moments where
latency is worst are exactly the moments where the JS timestamp is least accurate.

### Solution

Stamp the receive time in native code — at the point where the OS hands the buffer to the
app — before the native→JS bridge crossing. Two values are captured per message:

| Field | Type | Source | Meaning |
|---|---|---|---|
| `nativeReceivedEpochMs` | `number` | native | Wall-clock epoch ms. Directly subtractable from a server broadcast timestamp for one-way latency. |
| `nativeReceivedMonotonicMs` | `number` | native | Device-monotonic ms (`elapsedRealtimeNanos` / `CACurrentMediaTime`). Accurate for inter-arrival jitter; not comparable across devices. |

Both fields are forwarded through the native event and copied onto the `MessageEvent`
dispatched by `RTCDataChannel`. They are absent on web — consumers must guard with
`typeof ev.nativeReceivedEpochMs === 'number'` before using them.

### Changes

- **Android** (`DataChannelWrapper.java`): captures `System.currentTimeMillis()` and
  `SystemClock.elapsedRealtimeNanos()` as the very first statements in `onMessage`, before
  any buffer copy or encoding work, and emits both as `nativeReceivedEpochMs` /
  `nativeReceivedMonotonicMs` in the event map.

- **iOS** (`WebRTCModule+RTCDataChannel.m`): captures `[NSDate date]` epoch and
  `CACurrentMediaTime()` as the very first statements in
  `dataChannel:didReceiveMessageWithBuffer:` and includes both in the event dictionary.
  Requires `QuartzCore` (already available in all RN apps).

- **JS** (`RTCDataChannel.ts`): when the native fields are present on the raw event,
  copies them onto the `MessageEvent` before dispatching. No change in behaviour when
  the fields are absent (web, or older native builds).

### Backwards compatibility

Purely additive. No existing fields are changed. Consumers that do not read the new fields
are unaffected.