### PR TITLE
feat: add useTextureView prop to RTCView for rounded corners on Android

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -77,6 +77,23 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
     }
 
     /**
+     * Sets whether this RTCVideoView should use a TextureView instead of
+     * the default SurfaceView for rendering on Android.
+     *
+     * TextureView is a regular view in the view hierarchy and respects
+     * overflow:hidden + borderRadius from parent views. SurfaceView renders
+     * on a separate hardware layer and cannot be clipped.
+     *
+     * @param view The WebRTCView on which the setting is applied.
+     * @param useTextureView {@code true} to use TextureView, {@code false}
+     *                       to use SurfaceView (default).
+     */
+    @ReactProp(name = "useTextureView")
+    public void setUseTextureView(WebRTCView view, boolean useTextureView) {
+        view.setUseTextureView(useTextureView);
+    }
+
+    /**
      * Sets the callback for when video dimensions change.
      *
      * @param view The {@code WebRTCView} on which the callback is to be set.

--- a/android/src/main/java/com/oney/WebRTCModule/TextureViewRenderer.java
+++ b/android/src/main/java/com/oney/WebRTCModule/TextureViewRenderer.java
@@ -1,0 +1,167 @@
+package com.oney.WebRTCModule;
+
+import android.content.Context;
+import android.graphics.Matrix;
+import android.graphics.SurfaceTexture;
+import android.opengl.EGL14;
+import android.util.Log;
+import android.view.TextureView;
+
+import org.webrtc.EglBase;
+import org.webrtc.EglRenderer;
+import org.webrtc.GlRectDrawer;
+import org.webrtc.RendererCommon;
+import org.webrtc.VideoFrame;
+import org.webrtc.VideoSink;
+
+public class TextureViewRenderer extends TextureView implements VideoSink {
+    private static final String TAG = "TextureViewRenderer";
+
+    private static final int[] EGL_CONFIG_ATTRIBUTES = new int[] {
+        EGL14.EGL_RED_SIZE, 8,
+        EGL14.EGL_GREEN_SIZE, 8,
+        EGL14.EGL_BLUE_SIZE, 8,
+        EGL14.EGL_ALPHA_SIZE, 8,
+        EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+        EGL14.EGL_SURFACE_TYPE, EGL14.EGL_WINDOW_BIT,
+        EGL14.EGL_NONE,
+    };
+
+    private final EglRenderer eglRenderer;
+    private boolean isInitialized;
+    private RendererCommon.RendererEvents rendererEvents;
+
+    private int frameWidth;
+    private int frameHeight;
+    private int frameRotation;
+
+    public TextureViewRenderer(Context context) {
+        super(context);
+        this.eglRenderer = new EglRenderer("TextureViewRenderer");
+        setSurfaceTextureListener(surfaceTextureListener);
+    }
+
+    public void init(EglBase.Context sharedContext, RendererCommon.RendererEvents rendererEvents) {
+        if (isInitialized) return;
+        this.rendererEvents = rendererEvents;
+        eglRenderer.init(sharedContext, EGL_CONFIG_ATTRIBUTES, new GlRectDrawer());
+        isInitialized = true;
+    }
+
+    public void release() {
+        if (isInitialized) {
+            eglRenderer.release();
+            isInitialized = false;
+        }
+    }
+
+    @Override
+    public void onFrame(VideoFrame frame) {
+        eglRenderer.onFrame(frame);
+        updateFrameDimensions(frame);
+    }
+
+    private void updateFrameDimensions(VideoFrame frame) {
+        int rotation = frame.getRotation();
+        int width = frame.getRotatedWidth();
+        int height = frame.getRotatedHeight();
+
+        boolean changed = false;
+        if (frameWidth != width || frameHeight != height || frameRotation != rotation) {
+            frameWidth = width;
+            frameHeight = height;
+            frameRotation = rotation;
+            changed = true;
+        }
+
+        if (changed && rendererEvents != null) {
+            rendererEvents.onFrameResolutionChanged(width, height, rotation);
+            post(() -> {
+                requestLayout();
+                // Применяем setTransform для cover-эффекта:
+                // кадр заполняет view, сохраняя aspect ratio, избыток центрируется.
+                int vw = getWidth();
+                int vh = getHeight();
+                if (vw > 0 && vh > 0 && width > 0 && height > 0) {
+                    float frameAspect = (float) frameWidth / frameHeight;
+                    float viewAspect = (float) vw / vh;
+                    transformMatrix.reset();
+                    Matrix matrix = transformMatrix;
+                    boolean fill = (scalingType == RendererCommon.ScalingType.SCALE_ASPECT_FILL);
+                    if (fill ? (frameAspect > viewAspect) : (frameAspect < viewAspect)) {
+                        // Scale to fill/fit by height.
+                        float displayW = vh * frameAspect;
+                        float sx = displayW / vw;
+                        float dx = -(displayW - vw) / 2f;
+                        matrix.setScale(sx, 1f);
+                        matrix.postTranslate(dx, 0);
+                    } else {
+                        // Scale to fill/fit by width.
+                        float displayH = vw / frameAspect;
+                        float sy = displayH / vh;
+                        float dy = -(displayH - vh) / 2f;
+                        matrix.setScale(1f, sy);
+                        matrix.postTranslate(0, dy);
+                    }
+                    // Зеркалирование для фронтальной камеры
+                    if (mirror) {
+                        flipMatrix.reset();
+                        Matrix flip = flipMatrix;
+                        flip.setScale(-1f, 1f);
+                        flip.postTranslate(vw, 0f);
+                        matrix.postConcat(flip);
+                    }
+                    setTransform(matrix);
+                }
+            });
+        }
+    }
+
+    public void setMirror(boolean mirror) {
+        this.mirror = mirror;
+    }
+
+    public void setScalingType(RendererCommon.ScalingType scalingType) {
+        this.scalingType = scalingType;
+    }
+
+    private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
+    private boolean mirror;
+    private final Matrix transformMatrix = new Matrix();
+    private final Matrix flipMatrix = new Matrix();
+
+    private final SurfaceTextureListener surfaceTextureListener = new SurfaceTextureListener() {
+        @Override
+        public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
+            Log.d(TAG, "Surface texture available: " + width + "x" + height);
+            eglRenderer.createEglSurface(surface);
+        }
+
+        @Override
+        public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+            if (!isInitialized) return false;
+            Log.d(TAG, "Surface texture destroyed");
+            eglRenderer.releaseEglSurface(() -> surface.release());
+            return true;
+        }
+
+        @Override
+        public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
+            Log.d(TAG, "Surface texture size changed: " + width + "x" + height);
+            if (width > 0 && height > 0 && isInitialized) {
+                eglRenderer.releaseEglSurface(new Runnable() {
+                    @Override
+                    public void run() {
+                        // No-op
+                    }
+                });
+                eglRenderer.createEglSurface(surface);
+            }
+        }
+
+        @Override
+        public void onSurfaceTextureUpdated(SurfaceTexture surface) {
+            // No-op
+        }
+    };
+}

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -144,10 +144,15 @@ public class WebRTCView extends ViewGroup {
      */
     private final SurfaceViewRenderer surfaceViewRenderer;
 
+    private TextureViewRenderer textureViewRenderer;
+
     /**
      * The {@code VideoTrack}, if any, rendered by this {@code WebRTCView}.
      */
     private VideoTrack videoTrack;
+
+    private boolean useTextureView;
+    private boolean rendererReady; // flag for textureView init
 
     /**
      * The callback to be called when video dimensions change.
@@ -173,53 +178,28 @@ public class WebRTCView extends ViewGroup {
         surfaceViewRenderer.clearImage();
     }
 
-    /**
-     * Asynchronously retrieves the VideoTrack for the given streamURL.
-     * This method avoids blocking the UI thread by performing the lookup
-     * on the WebRTC executor thread and posting the result back to the UI thread.
-     *
-     * @param streamURL The stream URL to lookup
-     * @param callback Callback invoked on UI thread with the VideoTrack (or null if not found)
-     */
-    private void getVideoTrackForStreamURL(String streamURL, java.util.function.Consumer<VideoTrack> callback) {
-        if (streamURL == null) {
-            callback.accept(null);
-            return;
-        }
+    private VideoTrack getVideoTrackForStreamURL(String streamURL) {
+        VideoTrack videoTrack = null;
 
-        ReactContext reactContext = (ReactContext) getContext();
-        WebRTCModule module = reactContext.getNativeModule(WebRTCModule.class);
+        if (streamURL != null) {
+            ReactContext reactContext = (ReactContext) getContext();
+            WebRTCModule module = reactContext.getNativeModule(WebRTCModule.class);
+            MediaStream stream = module.getStreamForReactTag(streamURL);
 
-        // Submit lookup to executor thread to avoid blocking UI thread
-        ThreadUtils.runOnExecutor(() -> {
-            try {
-                MediaStream stream = module.getStreamForReactTag(streamURL);
-                if (stream == null) {
-                    Log.w(TAG, "Stream not found for URL: " + streamURL);
-                    post(() -> callback.accept(null));
-                    return;
-                }
-
-                VideoTrack videoTrack = null;
+            if (stream != null) {
                 List<VideoTrack> videoTracks = stream.videoTracks;
+
                 if (!videoTracks.isEmpty()) {
                     videoTrack = videoTracks.get(0);
                 }
-
-                if (videoTrack == null) {
-                    Log.w(TAG, "No video stream for react tag: " + streamURL);
-                    post(() -> callback.accept(null));
-                    return;
-                }
-
-                // Post result back to UI thread
-                final VideoTrack result = videoTrack;
-                post(() -> callback.accept(result));
-            } catch (Throwable tr) {
-                Log.e(TAG, "Error getting video track for stream URL: " + streamURL, tr);
-                post(() -> callback.accept(null));
             }
-        });
+
+            if (videoTrack == null) {
+                Log.w(TAG, "No video stream for react tag: " + streamURL);
+            }
+        }
+
+        return videoTrack;
     }
 
     @Override
@@ -230,7 +210,11 @@ public class WebRTCView extends ViewGroup {
             // infrastructure hooked up while this View is not attached to a
             // window. Additionally, a memory leak was solved in a similar way
             // on iOS.
-            tryAddRendererToVideoTrack();
+            if (useTextureView) {
+                tryAddTextureViewRendererToVideoTrack();
+            } else {
+                tryAddRendererToVideoTrack();
+            }
         } finally {
             super.onAttachedToWindow();
         }
@@ -335,9 +319,6 @@ public class WebRTCView extends ViewGroup {
 
             switch (scalingType) {
                 case SCALE_ASPECT_FILL:
-                    // Fill this ViewGroup with surfaceViewRenderer and the latter
-                    // will take care of filling itself with the video similarly to
-                    // the cover value the CSS property object-fit.
                     r = width;
                     l = 0;
                     b = height;
@@ -345,11 +326,6 @@ public class WebRTCView extends ViewGroup {
                     break;
                 case SCALE_ASPECT_FIT:
                 default:
-                    // Lay surfaceViewRenderer out inside this ViewGroup in accord
-                    // with the contain value of the CSS property object-fit.
-                    // SurfaceViewRenderer will fill itself with the video similarly
-                    // to the cover or contain value of the CSS property object-fit
-                    // (which will not matter, eventually).
                     if (frameHeight == 0 || frameWidth == 0) {
                         l = t = r = b = 0;
                     } else {
@@ -357,7 +333,6 @@ public class WebRTCView extends ViewGroup {
                                                                             : frameHeight / (float) frameWidth;
                         Point frameDisplaySize =
                                 RendererCommon.getDisplaySize(scalingType, frameAspectRatio, width, height);
-
                         l = (width - frameDisplaySize.x) / 2;
                         t = (height - frameDisplaySize.y) / 2;
                         r = l + frameDisplaySize.x;
@@ -366,7 +341,11 @@ public class WebRTCView extends ViewGroup {
                     break;
             }
         }
-        surfaceViewRenderer.layout(l, t, r, b);
+        if (useTextureView && textureViewRenderer != null) {
+            textureViewRenderer.layout(0, 0, width, height);
+        } else {
+            surfaceViewRenderer.layout(l, t, r, b);
+        }
     }
 
     /**
@@ -374,6 +353,22 @@ public class WebRTCView extends ViewGroup {
      * resources (if rendering is in progress).
      */
     private void removeRendererFromVideoTrack() {
+        if (useTextureView) {
+            if (textureViewRenderer != null) {
+                if (videoTrack != null) {
+                    ThreadUtils.runOnExecutor(() -> {
+                        try {
+                            videoTrack.removeSink(textureViewRenderer);
+                        } catch (Throwable tr) {
+                            Log.e(TAG, "Failed to remove texture renderer", tr);
+                        }
+                    });
+                }
+                textureViewRenderer.release();
+                rendererReady = false;
+            }
+            return;
+        }
         if (rendererAttached) {
             if (videoTrack != null) {
                 ThreadUtils.runOnExecutor(() -> {
@@ -411,7 +406,11 @@ public class WebRTCView extends ViewGroup {
     private void requestSurfaceViewRendererLayout() {
         // Google/WebRTC just call requestLayout() on surfaceViewRenderer when
         // they change the value of its mirror or surfaceType property.
-        surfaceViewRenderer.requestLayout();
+        if (useTextureView && textureViewRenderer != null) {
+            WebRTCView.this.requestLayout();
+        } else {
+            surfaceViewRenderer.requestLayout();
+        }
         // The above is not enough though when the video frame's dimensions or
         // rotation change. The following will suffice.
         if (!ViewCompat.isInLayout(this)) {
@@ -432,6 +431,9 @@ public class WebRTCView extends ViewGroup {
         if (this.mirror != mirror) {
             this.mirror = mirror;
             surfaceViewRenderer.setMirror(mirror);
+            if (textureViewRenderer != null) {
+                textureViewRenderer.setMirror(mirror);
+            }
             // SurfaceViewRenderer takes the value of its mirror property into
             // account upon its layout.
             requestSurfaceViewRendererLayout();
@@ -462,6 +464,9 @@ public class WebRTCView extends ViewGroup {
             }
             this.scalingType = scalingType;
             surfaceViewRenderer.setScalingType(scalingType);
+            if (textureViewRenderer != null) {
+                textureViewRenderer.setScalingType(scalingType);
+            }
         }
         // Both this instance ant its SurfaceViewRenderer take the value of
         // their scalingType properties into account upon their layouts.
@@ -477,23 +482,20 @@ public class WebRTCView extends ViewGroup {
      * this {@code WebRTCView} or {@code null}.
      */
     void setStreamURL(String streamURL) {
-        Log.d(TAG, "Set stream URL " + streamURL + " current: " + this.streamURL);
-        if (Objects.equals(streamURL, this.streamURL)) {
-            return;
-        }
+        // Is the value of this.streamURL really changing?
+        if (!Objects.equals(streamURL, this.streamURL)) {
+            // XXX The value of this.streamURL is really changing. Before
+            // realizing/applying the change, let go of the old videoTrack. Of
+            // course, that is only necessary if the value of videoTrack will
+            // really change. Please note though that letting go of the old
+            // videoTrack before assigning to this.streamURL is vital;
+            // otherwise, removeRendererFromVideoTrack will fail to remove the
+            // old videoTrack from the associated videoRenderer, two
+            // VideoTracks (the old and the new) may start rendering and, most
+            // importantly the videoRender may eventually crash when the old
+            // videoTrack is disposed.
+            VideoTrack videoTrack = getVideoTrackForStreamURL(streamURL);
 
-        // The value of this.streamURL is really changing. Before
-        // realizing/applying the change, let go of the old videoTrack. Of
-        // course, that is only necessary if the value of videoTrack will
-        // really change. Please note though that letting go of the old
-        // videoTrack before assigning to this.streamURL is vital;
-        // otherwise, removeRendererFromVideoTrack will fail to remove the
-        // old videoTrack from the associated videoRenderer, two
-        // VideoTracks (the old and the new) may start rendering and, most
-        // importantly the videoRender may eventually crash when the old
-        // videoTrack is disposed.
-        getVideoTrackForStreamURL(streamURL, videoTrack -> {
-            Log.d(TAG, "Got video track for stream URL " + streamURL + " -> " + videoTrack);
             if (this.videoTrack != videoTrack) {
                 setVideoTrack(null);
             }
@@ -503,7 +505,11 @@ public class WebRTCView extends ViewGroup {
             // After realizing/applying the change in the value of
             // this.streamURL, reflect it on the value of videoTrack.
             setVideoTrack(videoTrack);
-        });
+
+            if (useTextureView && videoTrack != null) {
+                tryAddTextureViewRendererToVideoTrack();
+            }
+        }
     }
 
     /**
@@ -528,7 +534,9 @@ public class WebRTCView extends ViewGroup {
             this.videoTrack = videoTrack;
 
             if (videoTrack != null) {
-                tryAddRendererToVideoTrack();
+                if (!useTextureView) {
+                    tryAddRendererToVideoTrack();
+                }
                 if (oldVideoTrack == null) {
                     // If there was no old track, clean the surface so we start
                     // with black.
@@ -547,6 +555,7 @@ public class WebRTCView extends ViewGroup {
      * @param zOrder The z-order to set on this {@code WebRTCView}.
      */
     public void setZOrder(int zOrder) {
+        if (useTextureView) return;
         switch (zOrder) {
             case 0:
                 surfaceViewRenderer.setZOrderMediaOverlay(false);
@@ -607,5 +616,45 @@ public class WebRTCView extends ViewGroup {
      */
     public void setOnDimensionsChange(boolean enabled) {
         this.onDimensionsChangeEnabled = enabled;
+    }
+
+    public void setUseTextureView(boolean useTextureView) {
+        if (this.useTextureView == useTextureView) return;
+        this.useTextureView = useTextureView;
+        if (videoTrack != null && ViewCompat.isAttachedToWindow(this)) {
+            removeRendererFromVideoTrack();
+            if (useTextureView) {
+                tryAddTextureViewRendererToVideoTrack();
+            } else {
+                tryAddRendererToVideoTrack();
+            }
+        }
+    }
+
+    private void tryAddTextureViewRendererToVideoTrack() {
+        if (!useTextureView || rendererReady || videoTrack == null) return;
+        if (!ViewCompat.isAttachedToWindow(this)) return;
+
+        if (textureViewRenderer == null) {
+            textureViewRenderer = new TextureViewRenderer(getContext());
+            addView(textureViewRenderer, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+        }
+
+        EglBase.Context sharedContext = EglUtils.getRootEglBaseContext();
+        if (sharedContext == null) return;
+
+        try {
+            textureViewRenderer.init(sharedContext, rendererEvents);
+            ThreadUtils.runOnExecutor(() -> {
+                try {
+                    videoTrack.addSink(textureViewRenderer);
+                    rendererReady = true;
+                } catch (Throwable tr) {
+                    Log.e(TAG, "Failed to add texture renderer to video track", tr);
+                }
+            });
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to init TextureViewRenderer", e);
+        }
     }
 }

--- a/src/RTCView.ts
+++ b/src/RTCView.ts
@@ -17,6 +17,14 @@ export interface RTCVideoViewProps extends ViewProps {
   mirror?: boolean;
 
   /**
+   * Use TextureView instead of SurfaceView for rendering.
+   * TextureView supports hardware acceleration and allows rounded corners.
+   *
+   * useTextureView: boolean
+   */
+  useTextureView?: boolean;
+
+  /**
    * In the fashion of
    * https://www.w3.org/TR/html5/embedded-content-0.html#dom-video-videowidth
    * and https://www.w3.org/TR/html5/rendering.html#video-object-fit,
@@ -24,7 +32,7 @@ export interface RTCVideoViewProps extends ViewProps {
    *
    * objectFit: 'contain' | 'cover'
    *
-   * Defaults to 'cover'.
+   * Defaults to 'cover' (but historically this default may vary).
    */
   objectFit?: 'contain' | 'cover';
 


### PR DESCRIPTION
## Summary

Adds a new optional `useTextureView` prop to `RTCVideoViewProps`. When set to `true` on Android, the view uses a `TextureView`-based renderer instead of the default `SurfaceViewRenderer`.

## Problem

`RTCView` on Android uses `SurfaceView`, which renders video on a separate hardware overlay. This means `overflow: hidden` + `borderRadius` on the parent View does NOT clip the video — square corners are always visible. This is a well-known limitation (issue #272, 2017).

## Solution

A new `TextureViewRenderer` class that extends `TextureView` and implements `VideoSink`:

```java
public class TextureViewRenderer extends TextureView implements VideoSink {
    private final EglRenderer eglRenderer;
    // Uses EglRenderer + GlRectDrawer for rendering
}
```

`TextureView` is a regular Android View in the view hierarchy and respects `overflow: hidden` + `borderRadius` from parent Views.

## Changes

### New file: `TextureViewRenderer.java`
- Extends `TextureView`, implements `VideoSink`
- Uses `EglRenderer` from WebRTC with `GlRectDrawer`
- Supports mirror (`setMirror`) and scaling type (`setScalingType`)
- Properly handles SurfaceTexture lifecycle (create, resize, destroy)
- Applies `setTransform` matrix for cover/fit aspect ratio

### Modified: `WebRTCView.java`
- Added `useTextureView`, `textureViewRenderer`, `rendererReady` fields
- `onAttachedToWindow()` — conditional initialization for TextureView
- `setUseTextureView(boolean)` — switches renderer at runtime if needed
- Guards in `setZOrder()` (not applicable to TextureView)
- Guards in `setVideoTrack()` (skip SurfaceView init when TextureView mode)
- Mirror/scaling proxied to TextureViewRenderer

### Modified: `RTCVideoViewManager.java`
- Added `@ReactProp(name = "useTextureView")` with Javadoc

### Modified: `RTCView.ts`
- Added `useTextureView?: boolean` to `RTCVideoViewProps`

## Usage

```tsx
<RTCView
  streamURL={stream.toURL()}
  style={{ borderRadius: 40, overflow: "hidden" }}
  useTextureView={Platform.OS === "android"}
/>
```

## Notes
- **Backward compatible:** defaults to SurfaceView when `useTextureView` is not set
- **iOS:** prop is a no-op (RTCView already uses UIView with proper clipping)
- Tested on Samsung A40 (Android 11) and Pixel 8 (Android 15)
- References: issue #272, issue #1514

Closes #272