### PR TITLE
registerGlobals: don't set RTCRtpSender/RTCRtpReceiver twice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,6 @@ function registerGlobals(): void {
     global.RTCIceCandidate = RTCIceCandidate;
     global.RTCCertificate = RTCCertificate;
     global.RTCPeerConnection = RTCPeerConnection;
-    global.RTCRtpReceiver = RTCRtpReceiver;
-    global.RTCRtpSender = RTCRtpReceiver;
     global.RTCSessionDescription = RTCSessionDescription;
     global.MediaStream = MediaStream;
     global.MediaStreamTrack = MediaStreamTrack;


### PR DESCRIPTION
in particular when the first instance is wrongly setting the sender to the receiver

(correct operation is a few lines down)