### PR TITLE
dispose the peer connection after signalingState changes to "closed"

### DIFF
--- a/src/RTCPeerConnection.ts
+++ b/src/RTCPeerConnection.ts
@@ -719,13 +719,6 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
             this.connectionState = ev.connectionState;
 
             this.dispatchEvent(new Event('connectionstatechange'));
-
-            if (ev.connectionState === 'closed') {
-                // This PeerConnection is done, clean up.
-                removeListener(this);
-
-                WebRTCModule.peerConnectionDispose(this._pcId);
-            }
         });
 
         addListener(this, 'peerConnectionSignalingStateChanged', (ev: any) => {
@@ -736,6 +729,13 @@ export default class RTCPeerConnection extends EventTarget<RTCPeerConnectionEven
             this.signalingState = ev.signalingState;
 
             this.dispatchEvent(new Event('signalingstatechange'));
+
+            if (ev.signalingState === 'closed') {
+                // This PeerConnection is done, clean up.
+                removeListener(this);
+
+                WebRTCModule.peerConnectionDispose(this._pcId);
+            }
         });
 
         // Consider moving away from this event: https://github.com/WebKit/WebKit/pull/3953


### PR DESCRIPTION
When close() is called, libwebrtc emits the observer state changes in the order iceConnectionState, connectionState, then signalingState (all "closed"). react-native-webrtc was tearing down its listeners on connectionState === "closed", which dropped the subsequent signalingState "closed" event, leaving signalingState stuck at its previous value. Move the teardown to the signalingState === "closed" handler so every final state change is applied before the listeners are removed.

See PeerConnection::Close():
https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/pc/peer_connection.cc;l=1818;drc=4e0c079a2b24c7ec577949494e94ba6f5bf264e4