### PR TITLE
android: fix frame leak with multiple video processors

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
+++ b/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoEffectProcessor.java
@@ -43,17 +43,17 @@ public class VideoEffectProcessor implements VideoProcessor {
         frame.retain();
         VideoFrame outputFrame = frame;
         for (VideoFrameProcessor processor : this.videoFrameProcessors) {
-            outputFrame = processor.process(outputFrame, textureHelper);
+            VideoFrame inputFrame = outputFrame;
+            outputFrame = processor.process(inputFrame, textureHelper);
+            inputFrame.release();
 
             if (outputFrame == null) {
                 mSink.onFrame(frame);
-                frame.release();
                 return;
             }
         }
 
         mSink.onFrame(outputFrame);
         outputFrame.release();
-        frame.release();
     }
 }


### PR DESCRIPTION
This affects the multi-processor pipeline introduced in #1681.

`VideoFrameProcessor.process()` returns a caller-owned frame. With a single
processor, the current implementation releases both the retained input and the
final output. With two or more processors, each loop iteration overwrites
`outputFrame` without releasing the previous returned frame.

| Reference | Acquired from | Released by the current code |
| --- | --- | --- |
| `F0` | Initial `frame.retain()` | `frame.release()` |
| `F1` | First processor result | No |
| `F2` | Second processor result | `outputFrame.release()` |

As a result, the intermediate `F1` reference remains retained after each
captured frame.

This change keeps the current input in a local variable and releases it after
the processor returns. The returned frame then becomes the single owned
reference carried to the next stage.

Returning the same frame remains supported when the processor calls `retain()`
before returning it, as required by the existing
[`VideoFrameProcessor` ownership contract](https://github.com/react-native-webrtc/react-native-webrtc/blob/cf6101cdfecff24ad2f57374dccd3026e5a11e4d/android/src/main/java/com/oney/WebRTCModule/videoEffects/VideoFrameProcessor.java#L6-L18).

This also keeps an empty processor list balanced: the final
`outputFrame.release()` matches the initial `frame.retain()`.

### Validation

- `git diff --check`
- Compiled `VideoFrameProcessor.java` and `VideoEffectProcessor.java` against
  the WebRTC M124 Java classes with `javac`
