### PR TITLE
fix(android): guard against duplicate onActivityResult crash in screen capture

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -75,6 +75,15 @@ class GetUserMediaImpl {
             public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
                 super.onActivityResult(activity, requestCode, resultCode, data);
                 if (requestCode == PERMISSION_REQUEST_CODE) {
+                    // Guard against a duplicate onActivityResult dispatch. Some hosts (e.g.
+                    // react-native-navigation) forward the activity result to every registered
+                    // ActivityEventListener more than once, so this callback can fire twice for a
+                    // single getDisplayMedia() request. The first pass consumes displayMediaPromise;
+                    // a second pass would call reject()/resolve() on a null promise and crash.
+                    if (displayMediaPromise == null) {
+                        return;
+                    }
+
                     if (resultCode != Activity.RESULT_OK) {
                         displayMediaPromise.reject("DOMException", "NotAllowedError");
                         displayMediaPromise = null;
@@ -357,6 +366,14 @@ class GetUserMediaImpl {
     }
 
     private void createScreenStream() {
+        // A duplicate onActivityResult dispatch (see onActivityResult above) can schedule this more
+        // than once. The single-threaded executor runs them in order, so by the time a duplicate
+        // runs the first has already consumed displayMediaPromise. Bail out instead of dereferencing
+        // a null promise or creating a second screen stream.
+        if (displayMediaPromise == null) {
+            return;
+        }
+
         VideoTrack track = createScreenTrack();
 
         if (track == null) {


### PR DESCRIPTION
## Problem

On Android, starting screen capture via `getDisplayMedia()` can crash with:

```
java.lang.NullPointerException: Attempt to invoke interface method
'void com.facebook.react.bridge.Promise.resolve(java.lang.Object)' on a null object reference
    at com.oney.WebRTCModule.GetUserMediaImpl.lambda$createScreenStream$1(GetUserMediaImpl.java)
    at com.oney.WebRTCModule.GetUserMediaImpl.createScreenStream(GetUserMediaImpl.java)
    at com.oney.WebRTCModule.GetUserMediaImpl$1.onActivityResult(GetUserMediaImpl.java)
```

## Root cause

Some hosts forward the Activity result to **every** registered `ActivityEventListener` more than once. [react-native-navigation](https://github.com/wix/react-native-navigation) is a common example (its `NavigationActivity` dispatches `onActivityResult` twice). When that happens during the screen-capture permission flow, `onActivityResult` fires twice for a single `getDisplayMedia()` request:

1. First dispatch → `createScreenStream()` → resolves `displayMediaPromise` and sets it to `null`.
2. Second dispatch → `createScreenStream()` again → calls `displayMediaPromise.resolve(...)` on the now-`null` promise → **NPE**.

It also spins up a second `MediaProjection` virtual display before crashing.

This reproduces reliably in a react-native-navigation app on Android 14/15 (`targetSdk` 34/35): entering a conference, tapping screen share, and confirming the system consent dialog crashes the app immediately.

## Fix

Two small null-guards so a duplicate dispatch is a no-op:

- One at the top of the `PERMISSION_REQUEST_CODE` branch — covers the cancel path, which nulls `displayMediaPromise` synchronously.
- One at the top of `createScreenStream()` — covers the success path. Because the callbacks run on the single-threaded executor, by the time a duplicated call runs the first has already consumed `displayMediaPromise`, so bailing out prevents both the NPE and a second screen stream.

No behavior change for the normal (single-dispatch) case.